### PR TITLE
Refactor: Admin basepath

### DIFF
--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -29,7 +29,7 @@ export type CreateAppConfig = {
         };
    initialConfig?: InitialModuleConfigs;
    plugins?: AppPlugin<any>[];
-   options?: ModuleManagerOptions;
+   options?: Omit<ModuleManagerOptions, "initial" | "onUpdated">;
 };
 
 export type AppConfig = InitialModuleConfigs;

--- a/app/src/modules/server/AdminController.tsx
+++ b/app/src/modules/server/AdminController.tsx
@@ -10,7 +10,9 @@ import * as SystemPermissions from "modules/permissions";
 
 const htmlBkndContextReplace = "<!-- BKND_CONTEXT -->";
 
+// @todo: add migration to remove admin path from config
 export type AdminControllerOptions = {
+   basepath?: string;
    html?: string;
    forceDev?: boolean;
 };
@@ -25,8 +27,12 @@ export class AdminController implements ClassController {
       return this.app.modules.ctx();
    }
 
+   get basepath() {
+      return this.options.basepath ?? "/";
+   }
+
    private withBasePath(route: string = "") {
-      return (this.app.modules.configs().server.admin.basepath + route).replace(/\/+$/, "/");
+      return (this.basepath + route).replace(/\/+$/, "/");
    }
 
    getController(): Hono<any> {


### PR DESCRIPTION
Use the admin UI basepath from registration method instead of configuration. The basepath of the admin is more of an environmental decision rather than a configuration that should be inside the database, and so it causes issues depending on where the admin of a given instance is rendered