### PR TITLE
feat/auth-redirect-param

### DIFF
--- a/app/src/auth/authenticate/Authenticator.ts
+++ b/app/src/auth/authenticate/Authenticator.ts
@@ -299,8 +299,8 @@ export class Authenticator<Strategies extends Record<string, Strategy> = Record<
       }
    }
 
-   private getSuccessPath(c: Context) {
-      const p = (this.config.cookie.pathSuccess ?? "/").replace(/\/+$/, "/");
+   private getSafeUrl(c: Context, path: string) {
+      const p = path.replace(/\/+$/, "/");
 
       // nextjs doesn't support non-fq urls
       // but env could be proxied (stackblitz), so we shouldn't fq every url
@@ -316,7 +316,10 @@ export class Authenticator<Strategies extends Record<string, Strategy> = Record<
          return c.json(data);
       }
 
-      const successUrl = this.getSuccessPath(c);
+      const successUrl = this.getSafeUrl(
+         c,
+         redirect ? redirect : (this.config.cookie.pathSuccess ?? "/")
+      );
       const referer = redirect ?? c.req.header("Referer") ?? successUrl;
       //console.log("auth respond", { redirect, successUrl, successPath });
 

--- a/app/src/auth/authenticate/Authenticator.ts
+++ b/app/src/auth/authenticate/Authenticator.ts
@@ -316,10 +316,7 @@ export class Authenticator<Strategies extends Record<string, Strategy> = Record<
          return c.json(data);
       }
 
-      const successUrl = this.getSafeUrl(
-         c,
-         redirect ? redirect : (this.config.cookie.pathSuccess ?? "/")
-      );
+      const successUrl = this.getSafeUrl(c, redirect ?? this.config.cookie.pathSuccess ?? "/");
       const referer = redirect ?? c.req.header("Referer") ?? successUrl;
       //console.log("auth respond", { redirect, successUrl, successPath });
 


### PR DESCRIPTION
Now you can add a `redirect` param to your login/register form action, to be redirected to that path:

```html
<form method="POST" action="/api/auth/password/login?redirect=/some/where/nice">
 {/* ... */}
</form>
```