### PR TITLE
update app create config to accept libsql config directly

### DIFF
--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -30,9 +30,11 @@ export type CreateAppConfig = {
    connection?:
       | Connection
       | {
+           // @deprecated
            type: "libsql";
            config: LibSqlCredentials;
-        };
+        }
+      | LibSqlCredentials;
    initialConfig?: InitialModuleConfigs;
    plugins?: AppPlugin[];
    options?: Omit<ModuleManagerOptions, "initial" | "onUpdated">;
@@ -179,7 +181,14 @@ export function createApp(config: CreateAppConfig = {}) {
       if (Connection.isConnection(config.connection)) {
          connection = config.connection;
       } else if (typeof config.connection === "object") {
-         connection = new LibsqlConnection(config.connection.config);
+         if ("type" in config.connection) {
+            console.warn(
+               "[WARN] Using deprecated connection type 'libsql', use the 'config' object directly."
+            );
+            connection = new LibsqlConnection(config.connection.config);
+         } else {
+            connection = new LibsqlConnection(config.connection);
+         }
       } else {
          connection = new LibsqlConnection({ url: ":memory:" });
          console.warn("[!] No connection provided, using in-memory database");

--- a/app/src/cli/commands/run/run.ts
+++ b/app/src/cli/commands/run/run.ts
@@ -104,7 +104,7 @@ async function action(options: {
    let app: App;
    if (options.dbUrl || !configFilePath) {
       const connection = options.dbUrl
-         ? { type: "libsql" as const, config: { url: options.dbUrl, authToken: options.dbToken } }
+         ? { url: options.dbUrl, authToken: options.dbToken }
          : undefined;
       app = await makeApp({ connection, server: { platform: options.server } });
    } else {

--- a/app/src/data/connection/LibsqlConnection.ts
+++ b/app/src/data/connection/LibsqlConnection.ts
@@ -1,6 +1,6 @@
 import { type Client, type Config, type InStatement, createClient } from "@libsql/client";
 import { LibsqlDialect } from "@libsql/kysely-libsql";
-import { type DatabaseIntrospector, Kysely, ParseJSONResultsPlugin, sql } from "kysely";
+import { type DatabaseIntrospector, Kysely, ParseJSONResultsPlugin } from "kysely";
 import { FilterNumericKeysPlugin } from "../plugins/FilterNumericKeysPlugin";
 import { KyselyPluginRunner } from "../plugins/KyselyPluginRunner";
 import type { QB } from "./Connection";

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,4 +1,11 @@
-export { App, createApp, AppEvents, type AppConfig, type CreateAppConfig } from "./App";
+export {
+   App,
+   createApp,
+   AppEvents,
+   type AppConfig,
+   type CreateAppConfig,
+   type AppPlugin
+} from "./App";
 
 export {
    getDefaultConfig,
@@ -6,7 +13,8 @@ export {
    type ModuleConfigs,
    type ModuleSchemas,
    type ModuleManagerOptions,
-   type ModuleBuildContext
+   type ModuleBuildContext,
+   type InitialModuleConfigs
 } from "./modules/ModuleManager";
 
 export * as middlewares from "modules/middlewares";

--- a/app/vite.dev.ts
+++ b/app/vite.dev.ts
@@ -32,10 +32,7 @@ export default {
    async fetch(request: Request) {
       if (!app || recreate) {
          app = App.create({
-            connection: {
-               type: "libsql",
-               config: credentials
-            },
+            connection: credentials,
             initialConfig
          });
          app.emgr.onEvent(

--- a/docs/integration/astro.mdx
+++ b/docs/integration/astro.mdx
@@ -43,12 +43,9 @@ export const prerender = false;
 
 export const ALL = serve({
    connection: {
-      type: "libsql",
-      config: {
-         // location of your local Astro DB
-         // make sure to use a remote URL in production
-         url: "file:.astro/content.db"
-      }
+      // location of your local Astro DB
+      // make sure to use a remote URL in production
+      url: "file:.astro/content.db"
    }
 });
 ```

--- a/docs/integration/bun.mdx
+++ b/docs/integration/bun.mdx
@@ -19,11 +19,8 @@ import { serve } from "bknd/adapter/bun";
 // if the configuration is omitted, it uses an in-memory database
 serve({
    connection: {
-      type: "libsql",
-      config: {
-         url: process.env.DB_URL!,
-         authToken: process.env.DB_AUTH_TOKEN!
-      }
+      url: process.env.DB_URL!,
+      authToken: process.env.DB_AUTH_TOKEN!
    }
 });
 ```

--- a/docs/integration/cloudflare.mdx
+++ b/docs/integration/cloudflare.mdx
@@ -22,11 +22,8 @@ import { serve } from "bknd/adapter/cloudflare";
 export default serve<Env>({
    app: ({ env }) => ({
       connection: {
-         type: "libsql",
-         config: {
-            url: env.DB_URL,
-            authToken: env.DB_TOKEN
-         }
+         url: env.DB_URL,
+         authToken: env.DB_TOKEN
       }
    })
 });
@@ -83,11 +80,8 @@ import manifest from "__STATIC_CONTENT_MANIFEST";
 export default serve<Env>({
    app: ({ env }) => ({
       connection: {
-         type: "libsql",
-         config: {
-            url: env.DB_URL,
-            authToken: env.DB_TOKEN
-         }
+         url: env.DB_URL,
+         authToken: env.DB_TOKEN
       }
    }),
    onBuilt: async (app) => {

--- a/docs/integration/nextjs.mdx
+++ b/docs/integration/nextjs.mdx
@@ -20,11 +20,8 @@ export const config = {
 
 export default serve({
    connection: {
-      type: "libsql",
-      config: {
-         url: process.env.DB_URL!,
-         authToken: process.env.DB_AUTH_TOKEN!
-      }
+      url: process.env.DB_URL!,
+      authToken: process.env.DB_AUTH_TOKEN!
    }
 });
 ```

--- a/docs/integration/node.mdx
+++ b/docs/integration/node.mdx
@@ -20,10 +20,7 @@ import { serve } from "bknd/adapter/node";
 /** @type {import("bknd/adapter/node").NodeAdapterOptions} */
 const config = {
    connection: {
-      type: "libsql",
-      config: {
-         url: ":memory:"
-      }
+      url: ":memory:"
    }
 };
 

--- a/docs/integration/remix.mdx
+++ b/docs/integration/remix.mdx
@@ -16,10 +16,7 @@ import { serve } from "bknd/adapter/remix";
 
 const handler = serve({
    connection: {
-      type: "libsql",
-      config: {
-         url: "http://localhost:8080"
-      }
+      url: "http://localhost:8080"
    }
 });
 

--- a/docs/integration/vite.mdx
+++ b/docs/integration/vite.mdx
@@ -26,10 +26,7 @@ import { serve } from "bknd/adapter/vite";
 export default serve({
    mode: "cached", // that's the default
    connection: {
-      type: "libsql",
-      config: {
-         url: ":memory:"
-      }
+      url: ":memory:"
    }
 })
 ```

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -18,10 +18,7 @@ The easiest to get started is using SQLite as a file. When serving the API in th
 the function accepts an object with connection details. To use a file, use the following:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "file:<path/to/your/database.db>"
-   }
+   "url": "file:<path/to/your/database.db>"
 }
 ```
 Please note that using SQLite as a file is only supported in server environments.
@@ -36,10 +33,7 @@ turso dev
 The command will yield a URL. Use it in the connection object:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "http://localhost:8080"
-   }
+   "url": "http://localhost:8080"
 }
 ```
 
@@ -48,11 +42,8 @@ If you want to use LibSQL on Turso, [sign up for a free account](https://turso.t
 connection object to your new database:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "libsql://your-database-url.turso.io",
-      "authToken": "your-auth-token"
-   }
+   "url": "libsql://your-database-url.turso.io",
+   "authToken": "your-auth-token"
 }
 ```
 

--- a/docs/usage/introduction.mdx
+++ b/docs/usage/introduction.mdx
@@ -39,19 +39,16 @@ implements the `Fetch` API.
 The `CreateAppConfig` type is the main configuration object for the `createApp` function. It has
 the following properties:
 ```ts
+import type { App, InitialModuleConfigs, ModuleBuildContext } from "bknd";
 import type { Connection } from "bknd/data";
 import type { Config } from "@libsql/client";
 
 type AppPlugin = (app: App) => Promise<void> | void;
-type LibSqlCredentials = Config;
 
 type CreateAppConfig = {
    connection?:
       | Connection
-      | {
-           type: "libsql";
-           config: LibSqlCredentials;
-        };
+      | Config;
    initialConfig?: InitialModuleConfigs;
    plugins?: AppPlugin[];
    options?: {
@@ -63,17 +60,12 @@ type CreateAppConfig = {
 };
 ```
 ### `connection`
-The `connection` property is the main connection object to the database. It can be either an
-object with a type specifier (only `libsql` is supported at the moment) and the actual
-`Connection` class. The `libsql` connection object looks like this:
+The `connection` property is the main connection object to the database. It can be either an object with libsql config or the actual `Connection` class.
 
 ```ts
 const connection = {
-   type: "libsql",
-   config: {
-      url: string;
-      authToken?: string;
-   };
+   url: "<url>",
+   authToken: "<token>"
 }
 ```
 
@@ -168,6 +160,8 @@ but before its event is emitted. This is useful for adding custom routes or othe
 A simple plugin that adds a custom route looks like this:
 
 ```ts
+import type { AppPlugin } from "bknd";
+
 export const myPlugin: AppPlugin = (app) => {
    app.server.get("/hello", (c) => c.json({ hello: "world" }));
 };

--- a/examples/astro/src/pages/api/[...api].ts
+++ b/examples/astro/src/pages/api/[...api].ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
 import { App } from "bknd";
-import { registerLocalMediaAdapter, serve } from "bknd/adapter/astro";
+import { serve } from "bknd/adapter/astro";
+import { registerLocalMediaAdapter } from "bknd/adapter/node";
 import { boolean, em, entity, text } from "bknd/data";
 import { secureRandomString } from "bknd/utils";
 
@@ -26,10 +27,7 @@ declare module "bknd/core" {
 export const ALL = serve<APIContext>({
    // we can use any libsql config, and if omitted, uses in-memory
    connection: {
-      type: "libsql",
-      config: {
-         url: "file:test.db"
-      }
+      url: "file:test.db"
    },
    // an initial config is only applied if the database is empty
    initialConfig: {

--- a/examples/bun/index.ts
+++ b/examples/bun/index.ts
@@ -7,10 +7,7 @@ import { type BunBkndConfig, serve } from "bknd/adapter/bun";
 // this is optional, if omitted, it uses an in-memory database
 const config: BunBkndConfig = {
    connection: {
-      type: "libsql",
-      config: {
-         url: ":memory:"
-      }
+      url: ":memory:"
    },
    // this is only required to run inside the same workspace
    // leave blank if you're running this from a different project

--- a/examples/nextjs/src/pages/api/[...route].ts
+++ b/examples/nextjs/src/pages/api/[...route].ts
@@ -29,10 +29,7 @@ declare module "bknd/core" {
 export default serve({
    // we can use any libsql config, and if omitted, uses in-memory
    connection: {
-      type: "libsql",
-      config: {
-         url: "http://localhost:8080"
-      }
+      url: "http://localhost:8080"
    },
    // an initial config is only applied if the database is empty
    initialConfig: {

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -7,10 +7,7 @@ import { serve } from "bknd/adapter/node";
 /** @type {import("bknd/adapter/node").NodeBkndConfig} */
 const config = {
    connection: {
-      type: "libsql",
-      config: {
-         url: ":memory:"
-      }
+      url: ":memory:"
    },
    // this is only required to run inside the same workspace
    // leave blank if you're running this from a different project

--- a/examples/remix/app/routes/api.$.ts
+++ b/examples/remix/app/routes/api.$.ts
@@ -1,5 +1,6 @@
 import { App } from "bknd";
-import { registerLocalMediaAdapter, serve } from "bknd/adapter/remix";
+import { registerLocalMediaAdapter } from "bknd/adapter/node";
+import { serve } from "bknd/adapter/remix";
 import { boolean, em, entity, text } from "bknd/data";
 import { secureRandomString } from "bknd/utils";
 
@@ -22,10 +23,7 @@ declare module "bknd/core" {
 const handler = serve({
    // we can use any libsql config, and if omitted, uses in-memory
    connection: {
-      type: "libsql",
-      config: {
-         url: "file:test.db"
-      }
+      url: "file:test.db"
    },
    // an initial config is only applied if the database is empty
    initialConfig: {

--- a/examples/sw/sw.ts
+++ b/examples/sw/sw.ts
@@ -8,10 +8,7 @@ import { App } from "bknd";
 async function getBknd() {
    const bknd = App.create({
       connection: {
-         type: "libsql",
-         config: {
-            url: "http://localhost:8080"
-         }
+         url: "http://localhost:8080"
       }
    });
    await bknd.build();


### PR DESCRIPTION
Omit `type` for the connection object, since it's all libsql anyway. Custom connections must be used differently. Adding the type of "libsql" is still supported but will be removed in future releases.

```diff
createApp({
   connection: {
-     type: "libsql",
-     config: {
-       url: "..."
-     }
+     url: "..."
   }
});
```