### PR TITLE
refactor app constructor params to move manager into app options

### DIFF
--- a/app/src/adapter/bun/bun.adapter.ts
+++ b/app/src/adapter/bun/bun.adapter.ts
@@ -30,7 +30,6 @@ export function serve({
    distPath,
    connection,
    initialConfig,
-   plugins,
    options,
    port = config.server.default_port,
    onBuilt,
@@ -44,7 +43,6 @@ export function serve({
          const app = await createApp({
             connection,
             initialConfig,
-            plugins,
             options,
             onBuilt,
             buildConfig,

--- a/docs/usage/database.mdx
+++ b/docs/usage/database.mdx
@@ -17,10 +17,7 @@ The easiest to get started is using SQLite in-memory. When serving the API in th
 the function accepts an object with connection details. To use an in-memory database, you can either omit the object completely or explicitly use it as follows:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": ":memory:"
-   }
+   "url": ":memory:"
 }
 ```
 
@@ -29,10 +26,7 @@ Just like the in-memory option, using a file is just as easy:
 
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "file:<path/to/your/database.db>"
-   }
+   "url": "file:<path/to/your/database.db>"
 }
 ```
 Please note that using SQLite as a file is only supported in server environments.
@@ -47,10 +41,7 @@ turso dev
 The command will yield a URL. Use it in the connection object:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "http://localhost:8080"
-   }
+   "url": "http://localhost:8080"
 }
 ```
 
@@ -59,11 +50,8 @@ If you want to use LibSQL on Turso, [sign up for a free account](https://turso.t
 connection object to your new database:
 ```json
 {
-   "type": "libsql",
-   "config": {
-      "url": "libsql://your-database-url.turso.io",
-      "authToken": "your-auth-token"
-   }
+   "url": "libsql://your-database-url.turso.io",
+   "authToken": "your-auth-token"
 }
 ```
 

--- a/docs/usage/introduction.mdx
+++ b/docs/usage/introduction.mdx
@@ -44,18 +44,21 @@ import type { Connection } from "bknd/data";
 import type { Config } from "@libsql/client";
 
 type AppPlugin = (app: App) => Promise<void> | void;
+type ManagerOptions = {
+   basePath?: string;
+   trustFetched?: boolean;
+   onFirstBoot?: () => Promise<void>;
+   seed?: (ctx: ModuleBuildContext) => Promise<void>;
+};
 
 type CreateAppConfig = {
    connection?:
       | Connection
       | Config;
    initialConfig?: InitialModuleConfigs;
-   plugins?: AppPlugin[];
    options?: {
-      basePath?: string;
-      trustFetched?: boolean;
-      onFirstBoot?: () => Promise<void>;
-      seed?: (ctx: ModuleBuildContext) => Promise<void>;
+      plugins?: AppPlugin[];
+      manager?: ManagerOptions
    };
 };
 ```


### PR DESCRIPTION
If you were creating an app using module manager options, these have moved now in order to allow future app configuration options.

```diff
const app = createApp({
  connection: { /* ... */ },
  initialConfig: { /* ... */ },
  {
-    /* ... manager options ... */
-    verbosity: 2
+    manager: {
+      /* ... manager options ... */
+      verbosity: 2
+    }
  }
});
```
