### PR TITLE
hotfix 0.9.1 docker fails due to trying to open a browser

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "sideEffects": false,
   "bin": "./dist/cli/index.js",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Lightweight Firebase/Supabase alternative built to run anywhere — incl. Next.js, Remix, Astro, Cloudflare, Bun, Node, AWS Lambda & more.",
   "homepage": "https://bknd.io",
   "repository": {

--- a/app/src/cli/commands/run/platform.ts
+++ b/app/src/cli/commands/run/platform.ts
@@ -30,7 +30,11 @@ export async function attachServeStatic(app: any, platform: Platform) {
    app.module.server.client.get(config.server.assets_path + "*", await serveStatic(platform));
 }
 
-export async function startServer(server: Platform, app: any, options: { port: number }) {
+export async function startServer(
+   server: Platform,
+   app: any,
+   options: { port: number; open?: boolean },
+) {
    const port = options.port;
    console.log(`Using ${server} serve`);
 
@@ -55,7 +59,9 @@ export async function startServer(server: Platform, app: any, options: { port: n
 
    const url = `http://localhost:${port}`;
    console.info("Server listening on", url);
-   await open(url);
+   if (options.open) {
+      await open(url);
+   }
 }
 
 export async function getConfigPath(filePath?: string) {

--- a/app/src/cli/commands/run/run.ts
+++ b/app/src/cli/commands/run/run.ts
@@ -47,6 +47,7 @@ export const run: CliCommand = (program) => {
             .choices(PLATFORMS)
             .default(isBun ? "bun" : "node"),
       )
+      .addOption(new Option("--no-open", "don't open browser window on start"))
       .action(action);
 };
 
@@ -110,6 +111,7 @@ async function action(options: {
    dbUrl?: string;
    dbToken?: string;
    server: Platform;
+   open?: boolean;
 }) {
    colorizeConsole(console);
    const configFilePath = await getConfigPath(options.config);
@@ -145,5 +147,5 @@ async function action(options: {
       });
    }
 
-   await startServer(options.server, app, { port: options.port });
+   await startServer(options.server, app, { port: options.port, open: options.open });
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,10 +19,10 @@ RUN npm install @libsql/client
 
 # Create volume and init args
 VOLUME /data
-ENV DEFAULT_ARGS "--db-url file:/data/data.db"
+ENV DEFAULT_ARGS="--db-url file:/data/data.db"
 
 # Copy output from builder
 COPY --from=builder /output/dist ./dist
 
 EXPOSE 1337
-CMD ["pm2-runtime", "dist/cli/index.js run ${ARGS:-${DEFAULT_ARGS}}"]
+CMD ["pm2-runtime", "dist/cli/index.js run ${ARGS:-${DEFAULT_ARGS}} --no-open"]


### PR DESCRIPTION
the cli automatically tries to open a browser which fails in docker environment. added a new `--no-open` cli argument to prevent this behavior (automatically enabled in docker environment)