### PR TITLE
Fix Astro create CLI

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
-    "@astrojs/react": "^3.6.3",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@astrojs/react": "^4.2.2",
+    "@types/react": "^19.0.12",
+    "@types/react-dom": "^19.0.4",
     "astro": "^4.16.16",
     "bknd": "file:../../app",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "typescript": "^5.7.2"
   }
 }

--- a/examples/astro/tsconfig.json
+++ b/examples/astro/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION
With the latest Bknd v0.10.2, I found that Bknd's peer dependencies for React was v19, not v18, which the Astro example had. 

This PR fixes that and makes the CLI work properly. 

```bash
cameronpak@Mac app % bun cli create -i astro

$ LOCAL=1 bun src/cli/index.ts create -i astro
Failed to find Response internal state key

┌  👋 Welcome to the bknd create cli v0.10.2
│
│  Thanks for choosing to create a new project with bknd!
│
◇  Where to create your project?
│  ./bknd-astro-test
│
◇  Template downloaded
│
◆  Updated package name to bknd-astro-test
│
◇  Install dependencies?
│  Yes
│
■  Failed to install: Command failed: cd ./bknd-astro-test && npm install
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: bknd-astro-test@0.0.1
npm error Found: react@18.3.1
npm error node_modules/react
npm error   react@"^18.3.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@">=19" from bknd@0.10.2
npm error node_modules/bknd
npm error   bknd@"0.10.2" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/cameronpak/.npm/_logs/2025-03-30T02_03_18_542Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/cameronpak/.npm/_logs/2025-03-30T02_03_18_542Z-debug-0.log

│
└  Failed to create project.

Sorry that this happened. If you think this is a bug, please report it at: https://github.com/bknd-io/bknd/issues

error: script "cli" exited with code 1
```