### PR TITLE
docker: add option to overwrite bknd version used

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,12 @@ FROM node:20 as builder
 
 WORKDIR /app
 
+# define bknd version to be used as:
+# `docker build --build-arg VERSION=<version> -t bknd .`
+ARG VERSION=0.10.2
+
 # Install & copy required cli
-RUN npm install --omit=dev bknd@0.9.1
+RUN npm install --omit=dev bknd@${VERSION}
 RUN mkdir /output && cp -r node_modules/bknd/dist /output/dist
 
 # Stage 2: Final minimal image

--- a/docs/integration/docker.mdx
+++ b/docs/integration/docker.mdx
@@ -4,12 +4,9 @@ description: 'Official docker image for bknd'
 ---
 
 # Official `bknd` Docker image
-The docker image intentially doesn't copy any data into the image for now, so you can copy the
-Dockerfile and build the image anywhere.
+The docker image intentially doesn't copy any data into the image for now, so you can copy the Dockerfile and build the image anywhere.
 
-Locate the Dockerfile either by pulling the [repository](https://github.com/bknd-io/bknd) and navigating to the `docker`
-directory,
-or download from [here](https://github.com/bknd-io/bknd/blob/main/docker/Dockerfile).
+Locate the Dockerfile either by pulling the [repository](https://github.com/bknd-io/bknd) and navigating to the `docker` directory, or download from [here](https://github.com/bknd-io/bknd/blob/main/docker/Dockerfile).
 
 ## Building the Docker image
 To build the Docker image, run the following command:
@@ -18,6 +15,13 @@ To build the Docker image, run the following command:
 docker build -t bknd .
 ```
 
+If you want to override the bknd version used, you can pass a `VERSION` build argument:
+```bash
+docker build --build-arg VERSION=<version> -t bknd .
+````
+
+```bash
+
 ## Running the Docker container
 To run the Docker container, run the following command:
 
@@ -25,11 +29,7 @@ To run the Docker container, run the following command:
 docker run -p 1337:1337 bknd
 ```
 
-You can pass the same CLI arguments (see [Using the CLI](https://docs.bknd.io/cli) guide) to the
-docker container as you'd do with
-`npx bknd
-run`,
-like so:
+You can pass the same CLI arguments (see [Using the CLI](https://docs.bknd.io/cli) guide) to the docker container as you'd do with `npx bknd run`, like so:
 
 ```bash
 docker run -p 1337:1337 -e ARGS="--db-url file:/data/data.db" bknd


### PR DESCRIPTION
If you want to override the bknd version used, you can pass a `VERSION` build argument:
```bash
docker build --build-arg VERSION=<version> -t bknd .
````