### PR TITLE
cli: create: allow non-interactive create

### DIFF
--- a/app/src/cli/commands/create/templates/index.ts
+++ b/app/src/cli/commands/create/templates/index.ts
@@ -4,6 +4,7 @@ export type TemplateSetupCtx = {
    template: Template;
    dir: string;
    name: string;
+   skip: boolean;
 };
 
 export type Integration =


### PR DESCRIPTION
Allows to run the create cli without interaction:

```sh
npx bknd create -d <dir> -i <integration> --yes --clean
```