### PR TITLE
feat/api-custom-storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ packages/media/.env
 .git_old
 docker/tmp
 .debug
+.history

--- a/app/src/auth/api/AuthApi.ts
+++ b/app/src/auth/api/AuthApi.ts
@@ -4,19 +4,21 @@ import type { AuthResponse, SafeUser, Strategy } from "auth/authenticate/Authent
 import { type BaseModuleApiOptions, ModuleApi } from "modules/ModuleApi";
 
 export type AuthApiOptions = BaseModuleApiOptions & {
-   onTokenUpdate?: (token: string) => void | Promise<void>;
+   onTokenUpdate?: (token?: string) => void | Promise<void>;
+   credentials?: "include" | "same-origin" | "omit";
 };
 
 export class AuthApi extends ModuleApi<AuthApiOptions> {
    protected override getDefaultOptions(): Partial<AuthApiOptions> {
       return {
          basepath: "/api/auth",
+         credentials: "include",
       };
    }
 
    async login(strategy: string, input: any) {
       const res = await this.post<AuthResponse>([strategy, "login"], input, {
-         credentials: "include",
+         credentials: this.options.credentials,
       });
 
       if (res.ok && res.body.token) {
@@ -27,7 +29,7 @@ export class AuthApi extends ModuleApi<AuthApiOptions> {
 
    async register(strategy: string, input: any) {
       const res = await this.post<AuthResponse>([strategy, "register"], input, {
-         credentials: "include",
+         credentials: this.options.credentials,
       });
 
       if (res.ok && res.body.token) {
@@ -68,5 +70,7 @@ export class AuthApi extends ModuleApi<AuthApiOptions> {
       return this.get<Pick<AppAuthSchema, "strategies" | "basepath">>(["strategies"]);
    }
 
-   async logout() {}
+   async logout() {
+      await this.options.onTokenUpdate?.(undefined);
+   }
 }

--- a/app/src/modules/server/AdminController.tsx
+++ b/app/src/modules/server/AdminController.tsx
@@ -86,7 +86,7 @@ export class AdminController extends Controller {
       hono.use("*", async (c, next) => {
          const obj = {
             user: c.get("auth")?.user,
-            logout_route: this.withAdminBasePath(authRoutes.logout),
+            logout_route: authRoutes.logout,
             admin_basepath: this.options.adminBasepath,
          };
          const html = await this.getHtml(obj);

--- a/app/src/ui/components/code/CodeEditor.tsx
+++ b/app/src/ui/components/code/CodeEditor.tsx
@@ -1,4 +1,8 @@
-import { default as CodeMirror, type ReactCodeMirrorProps } from "@uiw/react-codemirror";
+import {
+   default as CodeMirror,
+   type ReactCodeMirrorProps,
+   EditorView,
+} from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
 import { html } from "@codemirror/lang-html";
 import { useTheme } from "ui/client/use-theme";
@@ -43,7 +47,7 @@ export default function CodeEditor({
          theme={theme === "dark" ? "dark" : "light"}
          editable={editable}
          basicSetup={_basicSetup}
-         extensions={extensions}
+         extensions={[...extensions, EditorView.lineWrapping]}
          {...props}
       />
    );

--- a/app/src/ui/components/overlay/Dropdown.tsx
+++ b/app/src/ui/components/overlay/Dropdown.tsx
@@ -19,6 +19,7 @@ export type DropdownItem =
         onClick?: () => void;
         destructive?: boolean;
         disabled?: boolean;
+        title?: string;
         [key: string]: any;
      };
 
@@ -142,6 +143,7 @@ export function Dropdown({
                   item.destructive && "text-red-500 hover:bg-red-600 hover:text-white",
                )}
                onClick={onClick}
+               title={item.title}
             >
                {space_for_icon && (
                   <div className="size-[16px] text-left mr-1.5 opacity-80">

--- a/app/src/ui/layouts/AppShell/Header.tsx
+++ b/app/src/ui/layouts/AppShell/Header.tsx
@@ -171,7 +171,8 @@ function UserMenu() {
          items.push({ label: "Login", onClick: handleLogin, icon: IconUser });
       } else {
          items.push({
-            label: `Logout ${auth.user.email}`,
+            label: "Logout",
+            title: `Logout ${auth.user.email}`,
             onClick: handleLogout,
             icon: IconKeyOff,
          });

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -49,6 +49,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .cm-editor {
    display: flex;
    flex: 1;
+   max-width: 100%;
 }
 
 .animate-fade-in {


### PR DESCRIPTION
Updates `Api` to accept a `storage` option:
```ts
export type ApiOptions = {
    storage?: {
        getItem: (key: string) => string | undefined | null | Promise<string | undefined | null>;
        setItem: (key: string, value: string) => void | Promise<void>;
        removeItem: (key: string) => void | Promise<void>;
    };
    // ...
}
```

This option may also be passed via `ClientProvider`:
```tsx
<ClientProvider storage={window.localStorage} />
```

Helpful for using a custom client side storage such as local storage or browser storage (when used in a chrome extension)