### PR TITLE
fix: add missing @clack/prompts dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.758.0",
     "@bluwy/giget-core": "^0.1.2",
+    "@clack/prompts": "^0.11.0",
     "@cloudflare/vitest-pool-workers": "^0.8.38",
     "@cloudflare/workers-types": "^4.20250606.0",
     "@dagrejs/dagre": "^1.1.4",

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@bluwy/giget-core": "^0.1.2",
+        "@clack/prompts": "^0.11.0",
         "@cloudflare/vitest-pool-workers": "^0.8.38",
         "@cloudflare/workers-types": "^4.20250606.0",
         "@dagrejs/dagre": "^1.1.4",
@@ -502,6 +503,10 @@
     "@bundled-es-modules/tough-cookie": ["@bundled-es-modules/tough-cookie@0.1.6", "", { "dependencies": { "@types/tough-cookie": "^4.0.5", "tough-cookie": "^4.1.4" } }, "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
+    "@clack/core": ["@clack/core@0.5.0", "https://registry.npmmirror.com/@clack/core/-/core-0.5.0.tgz", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "https://registry.npmmirror.com/@clack/prompts/-/prompts-0.11.0.tgz", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
 


### PR DESCRIPTION
While compiling the project locally, I found that the @clack/prompts dependency was missing, which caused the build to fail.

One such usage can be found in https://github.com/bknd-io/bknd/blob/fd966b6aef5b3ccbf4547912d2a5aee453cd98e0/app/src/cli/commands/user.ts#L6

there may be additional occurrences elsewhere.

This PR adds the missing dependency and updates the lock file to ensure consistency.

Please let me know if you have any questions. Thank you!

