### PR TITLE
feat: enhance SQLite connection configurations to allow WAL

### DIFF
--- a/app/src/adapter/bun/connection/BunSqliteConnection.spec.ts
+++ b/app/src/adapter/bun/connection/BunSqliteConnection.spec.ts
@@ -1,8 +1,9 @@
 import { connectionTestSuite } from "data/connection/connection-test-suite";
 import { bunSqlite } from "./BunSqliteConnection";
 import { bunTestRunner } from "adapter/bun/test";
-import { describe } from "bun:test";
+import { describe, test, mock, expect } from "bun:test";
 import { Database } from "bun:sqlite";
+import { GenericSqliteConnection } from "data/connection/sqlite/GenericSqliteConnection";
 
 describe("BunSqliteConnection", () => {
    connectionTestSuite(bunTestRunner, {
@@ -11,5 +12,21 @@ describe("BunSqliteConnection", () => {
          dispose: async () => {},
       }),
       rawDialectDetails: [],
+   });
+
+   test("onCreateConnection", async () => {
+      const called = mock(() => null);
+
+      const conn = bunSqlite({
+         onCreateConnection: (db) => {
+            expect(db).toBeInstanceOf(Database);
+            called();
+         },
+      });
+      await conn.ping();
+
+      expect(conn).toBeInstanceOf(GenericSqliteConnection);
+      expect(conn.db).toBeInstanceOf(Database);
+      expect(called).toHaveBeenCalledTimes(1);
    });
 });

--- a/app/src/adapter/bun/connection/BunSqliteConnection.ts
+++ b/app/src/adapter/bun/connection/BunSqliteConnection.ts
@@ -1,40 +1,53 @@
 import { Database } from "bun:sqlite";
-import { genericSqlite, type GenericSqliteConnection } from "bknd";
+import {
+   genericSqlite,
+   type GenericSqliteConnection,
+   type GenericSqliteConnectionConfig,
+} from "bknd";
+import { omitKeys } from "bknd/utils";
 
 export type BunSqliteConnection = GenericSqliteConnection<Database>;
-export type BunSqliteConnectionConfig = {
-   database: Database;
-};
+export type BunSqliteConnectionConfig = Omit<
+   GenericSqliteConnectionConfig<Database>,
+   "name" | "supports"
+> &
+   ({ database?: Database; url?: never } | { url?: string; database?: never });
 
-export function bunSqlite(config?: BunSqliteConnectionConfig | { url: string }) {
-   let db: Database;
+export function bunSqlite(config?: BunSqliteConnectionConfig) {
+   let db: Database | undefined;
    if (config) {
-      if ("database" in config) {
+      if ("database" in config && config.database) {
          db = config.database;
-      } else {
+      } else if (config.url) {
          db = new Database(config.url);
       }
-   } else {
+   }
+
+   if (!db) {
       db = new Database(":memory:");
    }
 
-   return genericSqlite("bun-sqlite", db, (utils) => {
-      //const fn = cache ? "query" : "prepare";
-      const getStmt = (sql: string) => db.prepare(sql);
+   return genericSqlite(
+      "bun-sqlite",
+      db,
+      (utils) => {
+         const getStmt = (sql: string) => db.prepare(sql);
 
-      return {
-         db,
-         query: utils.buildQueryFn({
-            all: (sql, parameters) => getStmt(sql).all(...(parameters || [])),
-            run: (sql, parameters) => {
-               const { changes, lastInsertRowid } = getStmt(sql).run(...(parameters || []));
-               return {
-                  insertId: utils.parseBigInt(lastInsertRowid),
-                  numAffectedRows: utils.parseBigInt(changes),
-               };
-            },
-         }),
-         close: () => db.close(),
-      };
-   });
+         return {
+            db,
+            query: utils.buildQueryFn({
+               all: (sql, parameters) => getStmt(sql).all(...(parameters || [])),
+               run: (sql, parameters) => {
+                  const { changes, lastInsertRowid } = getStmt(sql).run(...(parameters || []));
+                  return {
+                     insertId: utils.parseBigInt(lastInsertRowid),
+                     numAffectedRows: utils.parseBigInt(changes),
+                  };
+               },
+            }),
+            close: () => db.close(),
+         };
+      },
+      omitKeys(config ?? ({} as any), ["database", "url", "name", "supports"]),
+   );
 }

--- a/app/src/adapter/node/connection/NodeSqliteConnection.vi-test.ts
+++ b/app/src/adapter/node/connection/NodeSqliteConnection.vi-test.ts
@@ -1,9 +1,10 @@
 import { nodeSqlite } from "./NodeSqliteConnection";
 import { DatabaseSync } from "node:sqlite";
 import { connectionTestSuite } from "data/connection/connection-test-suite";
-import { describe, beforeAll, afterAll } from "vitest";
+import { describe, beforeAll, afterAll, test, expect, vi } from "vitest";
 import { viTestRunner } from "../vitest";
 import { disableConsoleLog, enableConsoleLog } from "core/utils/test";
+import { GenericSqliteConnection } from "data/connection/sqlite/GenericSqliteConnection";
 
 beforeAll(() => disableConsoleLog());
 afterAll(() => enableConsoleLog());
@@ -15,5 +16,21 @@ describe("NodeSqliteConnection", () => {
          dispose: async () => {},
       }),
       rawDialectDetails: [],
+   });
+
+   test("onCreateConnection", async () => {
+      const called = vi.fn(() => null);
+
+      const conn = nodeSqlite({
+         onCreateConnection: (db) => {
+            expect(db).toBeInstanceOf(DatabaseSync);
+            called();
+         },
+      });
+      await conn.ping();
+
+      expect(conn).toBeInstanceOf(GenericSqliteConnection);
+      expect(conn.db).toBeInstanceOf(DatabaseSync);
+      expect(called).toHaveBeenCalledOnce();
    });
 });

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -116,6 +116,7 @@ export {
    genericSqlite,
    genericSqliteUtils,
    type GenericSqliteConnection,
+   type GenericSqliteConnectionConfig,
 } from "data/connection/sqlite/GenericSqliteConnection";
 export {
    EntityTypescript,

--- a/docs/content/docs/(documentation)/usage/database.mdx
+++ b/docs/content/docs/(documentation)/usage/database.mdx
@@ -106,6 +106,23 @@ export default {
 } satisfies BkndConfig;
 ```
 
+### Node.js SQLite
+
+To use the Node.js SQLite adapter directly, use the `nodeSqlite` function as value for the `connection` property. This lets you customize the database connection, such as enabling WAL mode.
+
+```typescript title="bknd.config.ts"
+import { nodeSqlite, type NodeBkndConfig } from "bknd/adapter/node";
+
+export default {
+  connection: nodeSqlite({
+    url: "file:<path/to/your/database.db>",
+    onCreateConnection: (db) => {
+      db.exec("PRAGMA journal_mode = WAL;");
+    },
+  }),
+} satisfies NodeBkndConfig;
+```
+
 ### Bun SQLite
 
 You can explicitly use the Bun SQLite adapter by passing the `bunSqlite` function to the `connection` property. This allows further configuration of the database, e.g. enabling WAL mode.
@@ -121,23 +138,6 @@ export default {
     },
   }),
 } satisfies BunBkndConfig;
-```
-
-### Node.js SQLite
-
-To use the Node.js SQLite adapter directly, set the `connection` property to the result of the `nodeSqlite` function. This lets you customize the database connection, such as enabling WAL mode.
-
-```typescript title="bknd.config.ts"
-import { nodeSqlite, type NodeBkndConfig } from "bknd/adapter/node";
-
-export default {
-  connection: nodeSqlite({
-    url: "file:<path/to/your/database.db>",
-    onCreateConnection: (db) => {
-      db.exec("PRAGMA journal_mode = WAL;");
-    },
-  }),
-} satisfies NodeBkndConfig;
 ```
 
 ### LibSQL

--- a/docs/content/docs/(documentation)/usage/database.mdx
+++ b/docs/content/docs/(documentation)/usage/database.mdx
@@ -63,7 +63,7 @@ import type { BkndConfig } from "bknd";
 
 export default {
   connection: { url: "file:data.db" },
-} as const satisfies BkndConfig;
+} satisfies BkndConfig;
 ```
 
 Throughout the documentation, it is assumed you use `bknd.config.ts` to define your connection.
@@ -93,17 +93,51 @@ import type { BkndConfig } from "bknd";
 
 // no connection is required, bknd will use a SQLite database in-memory
 // this does not work on edge environments!
-export default {} as const satisfies BkndConfig;
+export default {} satisfies BkndConfig;
 
 // or explicitly in-memory
 export default {
   connection: { url: ":memory:" },
-} as const satisfies BkndConfig;
+} satisfies BkndConfig;
 
 // or explicitly as a file
 export default {
   connection: { url: "file:<path/to/your/database.db>" },
-} as const satisfies BkndConfig;
+} satisfies BkndConfig;
+```
+
+### Bun SQLite
+
+You can explicitly use the Bun SQLite adapter by passing the `bunSqlite` function to the `connection` property. This allows further configuration of the database, e.g. enabling WAL mode.
+
+```typescript title="bknd.config.ts"
+import { bunSqlite, type BunBkndConfig } from "bknd/adapter/bun";
+
+export default {
+  connection: bunSqlite({ 
+    url: "file:<path/to/your/database.db>",
+    onCreateConnection: (db) => {
+      db.run("PRAGMA journal_mode = WAL;");
+    },
+  }),
+} satisfies BunBkndConfig;
+```
+
+### Node.js SQLite
+
+To use the Node.js SQLite adapter directly, set the `connection` property to the result of the `nodeSqlite` function. This lets you customize the database connection, such as enabling WAL mode.
+
+```typescript title="bknd.config.ts"
+import { nodeSqlite, type NodeBkndConfig } from "bknd/adapter/node";
+
+export default {
+  connection: nodeSqlite({
+    url: "file:<path/to/your/database.db>",
+    onCreateConnection: (db) => {
+      db.exec("PRAGMA journal_mode = WAL;");
+    },
+  }),
+} satisfies NodeBkndConfig;
 ```
 
 ### LibSQL
@@ -118,7 +152,7 @@ export default {
     url: "libsql://<database>.turso.io",
     authToken: "<auth-token>",
   }),
-} as const satisfies BkndConfig;
+} satisfies BkndConfig;
 ```
 
 If you wish to use LibSQL as file, in-memory or make use of [Embedded Replicas](https://docs.turso.tech/features/embedded-replicas/introduction), you have to pass in the `Client` from `@libsql/client`:
@@ -134,7 +168,7 @@ const client = createClient({
 
 export default {
   connection: libsql(client),
-} as const satisfies BkndConfig;
+} satisfies BkndConfig;
 ```
 
 ### Cloudflare D1


### PR DESCRIPTION
Updated the Bun and Node SQLite connection implementations to support additional configuration options, including `onCreateConnection`. Introduced tests for connection creation to validate database instance types and ensure proper callback execution. Improved type exports for better integration with existing code.