### PR TITLE
feat: enhance entity field management with configurable order

### DIFF
--- a/app/src/data/schema/SchemaManager.ts
+++ b/app/src/data/schema/SchemaManager.ts
@@ -76,7 +76,7 @@ export class SchemaManager {
    }
 
    getIntrospectionFromEntity(entity: Entity): IntrospectedTable {
-      const fields = entity.getFields(false);
+      const fields = entity.getFields({ virtual: false, sorted: true });
       const indices = this.em.getIndicesOf(entity);
 
       // this is intentionally setting values to defaults, like "nullable" and "default"

--- a/app/src/ui/client/schema/data/use-bknd-data.ts
+++ b/app/src/ui/client/schema/data/use-bknd-data.ts
@@ -120,17 +120,20 @@ function entityFieldActions(bkndActions: TSchemaActions, entityName: string) {
          return await bkndActions.add("data", `entities.${entityName}.fields.${name}`, validated);
       },
       patch: () => null,
-      set: async (fields: TAppDataEntityFields) => {
+      set: async (fields: TAppDataEntityFields, order?: string[]) => {
          try {
             const validated = parse(entityFields, fields, {
                skipMark: true,
                forceParse: true,
             });
-            const res = await bkndActions.overwrite(
-               "data",
-               `entities.${entityName}.fields`,
-               validated,
-            );
+            await bkndActions.overwrite("data", `entities.${entityName}.fields`, validated);
+            if (order) {
+               await bkndActions.overwrite(
+                  "data",
+                  `entities.${entityName}.config.fields_order`,
+                  order,
+               );
+            }
          } catch (e) {
             console.error("error", e);
             if (e instanceof InvalidSchemaError) {

--- a/app/src/ui/routes/data/data.schema.$entity.tsx
+++ b/app/src/ui/routes/data/data.schema.$entity.tsx
@@ -155,17 +155,24 @@ const Fields = ({ entity }: { entity: Entity }) => {
    const { readonly } = useBknd();
    const [res, setRes] = useState<any>();
    const ref = useRef<EntityFieldsFormRef>(null);
+
+   // @todo: the return of toJSON from Fields doesn't match "type" enum
+   const initialFields = Object.fromEntries(entity.fields.map((f) => [f.name, f.toJSON()])) as any;
+
    async function handleUpdate() {
       if (submitting) return;
       setSubmitting(true);
       const fields = ref.current?.getData()!;
+
       await actions.entity.patch(entity.name).fields.set(fields);
+
+      // check if field order has changed
+      if (Object.keys(initialFields).join(",") !== Object.keys(fields).join(",")) {
+         await actions.entity.patch(entity.name).fields.set(fields, Object.keys(fields));
+      }
       setSubmitting(false);
       setUpdates((u) => u + 1);
    }
-
-   // @todo: the return of toJSON from Fields doesn't match "type" enum
-   const initialFields = Object.fromEntries(entity.fields.map((f) => [f.name, f.toJSON()])) as any;
 
    return (
       <AppShell.RouteAwareSectionHeaderAccordionItem


### PR DESCRIPTION
Added optional `fields_order` to the entity configuration schema, allowing for custom field sorting. Updated `getFields` method to support sorting based on this configuration. Adjusted related methods and UI components to handle field order during updates and serialization. Improved handling of virtual fields in various contexts.