### PR TITLE
Update docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 # Stage 1: Build stage
 FROM node:24 as builder
-
 WORKDIR /app
 
 # define bknd version to be used as:
@@ -9,7 +8,6 @@ ARG VERSION=0.18.0
 
 # Install & copy required cli
 RUN npm install --omit=dev bknd@${VERSION}
-RUN mkdir /output && cp -r node_modules/bknd/dist /output/dist
 
 # Stage 2: Final minimal image
 FROM node:24-alpine
@@ -19,14 +17,14 @@ WORKDIR /app
 # Install required dependencies
 RUN npm install -g pm2
 RUN echo '{"type":"module"}' > package.json
-RUN npm install jsonv-ts @libsql/client
+
+# Copy dist and node_modules from builder
+COPY --from=builder /app/node_modules/bknd/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 
 # Create volume and init args
 VOLUME /data
 ENV DEFAULT_ARGS="--db-url file:/data/data.db"
-
-# Copy output from builder
-COPY --from=builder /output/dist ./dist
 
 EXPOSE 1337
 CMD ["pm2-runtime", "dist/cli/index.js run ${ARGS:-${DEFAULT_ARGS}} --no-open"]


### PR DESCRIPTION
## Removed the intermediate /output copy
```
RUN mkdir /output && cp -r node_modules/bknd/dist /output/dist
```
replaced by direct copy in stage 2 — no temporary folder.

## Stage 2 adds
```
COPY --from=builder /app/node_modules/bknd/dist ./dist
COPY --from=builder /app/node_modules ./node_modules
```

These two lines bring both the compiled CLI (dist) and its installed dependencies (node_modules) from the builder image into the final image.

## Removed explicit install of only two libraries
````
RUN npm install jsonv-ts @libsql/client
```

now unnecessary because those (and every other dependency) already exist inside node_modules copied from builder.


- node:24-alpine runtime can now resolve all imports, including picocolors.
- Image remains smaller than a full reinstall because dependencies are reused, not rebuilt.
