### PR TITLE
docs: add note about Cloudflare Image Optimization plugin requirement

### DIFF
--- a/docs/content/docs/(documentation)/extending/plugins.mdx
+++ b/docs/content/docs/(documentation)/extending/plugins.mdx
@@ -167,6 +167,10 @@ export default {
 
 ### `cloudflareImageOptimization`
 
+<Callout type="info">
+  This plugin doesn't work on the development server, or on workers deployed with a `workers.dev` subdomain. It requires [Cloudflare Image transformations to be enabled](https://developers.cloudflare.com/images/get-started/#enable-transformations-on-your-zone) on your zone.
+</Callout>
+
 A plugin that add Cloudflare Image Optimization to your app's media storage.
 
 ```typescript title="bknd.config.ts"


### PR DESCRIPTION
Included a callout in the documentation for the Cloudflare Image Optimization plugin, clarifying that it does not function on the development server or with `workers.dev` subdomains, and requires enabling Cloudflare Image transformations.