### PR TITLE
Update Astro integration documentation

### DIFF
--- a/docs/content/docs/(documentation)/integration/(frameworks)/astro.mdx
+++ b/docs/content/docs/(documentation)/integration/(frameworks)/astro.mdx
@@ -40,12 +40,6 @@ bun add bknd
 
 </Tabs>
 
-<Callout type="info">
-  The guide below assumes you're using Astro v4. We've experienced issues with
-  Astro DB using v5, see [this
-  issue](https://github.com/withastro/astro/issues/12474).
-</Callout>
-
 For the Astro integration to work, you also need to [add the react integration](https://docs.astro.build/en/guides/integrations-guide/react/):
 
 ```bash


### PR DESCRIPTION
Removed note about Astro v4 and issues with v5. Issue was fixed on Dec 16, 2024 [https://github.com/withastro/astro/issues/12699]