### PR TITLE
fix: recursive `with` omitted join clauses

### DIFF
--- a/app/src/data/entities/query/WithBuilder.ts
+++ b/app/src/data/entities/query/WithBuilder.ts
@@ -4,6 +4,7 @@ import type { KyselyJsonFrom } from "data/relations/EntityRelation";
 import type { RepoQuery } from "data/server/query";
 import { InvalidSearchParamsException } from "data/errors";
 import type { Entity, EntityManager, RepositoryQB } from "data/entities";
+import { $console } from "bknd/utils";
 
 export class WithBuilder {
    static addClause(
@@ -13,7 +14,7 @@ export class WithBuilder {
       withs: RepoQuery["with"],
    ) {
       if (!withs || !isObject(withs)) {
-         console.warn(`'withs' undefined or invalid, given: ${JSON.stringify(withs)}`);
+         $console.warn(`'withs' undefined or invalid, given: ${JSON.stringify(withs)}`);
          return qb;
       }
 
@@ -37,9 +38,7 @@ export class WithBuilder {
             let subQuery = relation.buildWith(entity, ref)(eb);
             if (query) {
                subQuery = em.repo(other.entity).addOptionsToQueryBuilder(subQuery, query as any, {
-                  ignore: ["with", "join", cardinality === 1 ? "limit" : undefined].filter(
-                     Boolean,
-                  ) as any,
+                  ignore: ["with", cardinality === 1 ? "limit" : undefined].filter(Boolean) as any,
                });
             }
 
@@ -57,7 +56,7 @@ export class WithBuilder {
    static validateWiths(em: EntityManager<any>, entity: string, withs: RepoQuery["with"]) {
       let depth = 0;
       if (!withs || !isObject(withs)) {
-         withs && console.warn(`'withs' invalid, given: ${JSON.stringify(withs)}`);
+         withs && $console.warn(`'withs' invalid, given: ${JSON.stringify(withs)}`);
          return depth;
       }
 

--- a/app/src/modules/server/AppServer.ts
+++ b/app/src/modules/server/AppServer.ts
@@ -105,7 +105,10 @@ export class AppServer extends Module<AppServerConfig> {
 
          if (err instanceof Error) {
             if (isDebug()) {
-               return c.json({ error: err.message, stack: err.stack }, 500);
+               return c.json(
+                  { error: err.message, stack: err.stack?.split("\n").map((line) => line.trim()) },
+                  500,
+               );
             }
          }
 

--- a/app/vite.dev.ts
+++ b/app/vite.dev.ts
@@ -70,8 +70,9 @@ switch (dbType) {
       if (example) {
          const name = slugify(example);
          configPath = `.configs/${slugify(example)}.wrangler.json`;
-         const exists = await readFile(configPath, "utf-8");
-         if (!exists) {
+         try {
+            await readFile(configPath, "utf-8");
+         } catch (_e) {
             wranglerConfig.name = name;
             wranglerConfig.d1_databases[0]!.database_name = name;
             wranglerConfig.d1_databases[0]!.database_id = crypto.randomUUID();


### PR DESCRIPTION
The following query would have crashed with `"no such column: comments.content"` due to ignored `join` inside recursive `with`:

```http
POST /api/data/entity/users/query
Content-Type: application/json

{
   "with": {
      "posts": {
         "join": ["comments"],
         "where": {
            "comments.content": "test"
         }
      }
   }
}
```