### PR TITLE
Update bun version to 1.3.3 in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: "1.2.22"
+          bun-version: "1.3.3"
 
       - name: Install dependencies
         working-directory: ./app


### PR DESCRIPTION
This pull request updates the Bun version used in the GitHub Actions workflow for testing. The new version ensures the CI environment uses the latest stable features and fixes. 

* Updated Bun setup in `.github/workflows/test.yml` to use version `1.3.3` instead of `1.2.22`.