### PR TITLE
feat: Add implicit joins in repository where clauses

### DIFF
--- a/app/src/data/prototype/index.ts
+++ b/app/src/data/prototype/index.ts
@@ -289,7 +289,7 @@ class EntityManagerPrototype<Entities extends Record<string, Entity>> extends En
       super(Object.values(__entities), new DummyConnection(), relations, indices);
    }
 
-   withConnection(connection: Connection): EntityManager<Schema<Entities>> {
+   withConnection(connection: Connection): EntityManager<Schemas<Entities>> {
       return new EntityManager(this.entities, connection, this.relations.all, this.indices);
    }
 }


### PR DESCRIPTION
The repository/SDK now automatically adds joins when filtering by related entity fields in where clauses. You no longer need to manually specify joins when referencing related entities.

**Example:**

```typescript
// Before: manual join required
await em.repo("comments").findMany({
  join: ["posts"],
  where: {
    "posts.title": "My Post"
  }
});

// Now: automatic join
await em.repo("comments").findMany({
  where: {
    "posts.title": "My Post"
  }
});

// same with the SDK
await api.data.readMany("comments", {
  where: {
    "posts.title": "My Post"
  }
});
```

The repository validates that the relation exists and throws an error for invalid entity references or non-existent relations. Manual joins continue to work as before.