### PR TITLE
docs: Add documentation for auth.logout method in SDK usage

### DIFF
--- a/docs/content/docs/(documentation)/usage/sdk.mdx
+++ b/docs/content/docs/(documentation)/usage/sdk.mdx
@@ -266,6 +266,16 @@ const { data } = await api.auth.register("password", {
 });
 ```
 
+### `auth.logout()`
+
+To log out the current user and clear the stored token, use the `logout` method:
+
+```ts
+await api.auth.logout();
+```
+
+This method takes no parameters. It sends a request to the logout endpoint and clears the authentication token. Returns a `Promise<void>`.
+
 ### `auth.me()`
 
 To retrieve the current user, use the `me` method:


### PR DESCRIPTION
This pull request adds documentation for the `auth.logout()` method to the SDK usage guide. The new section explains how to log out the current user, clear the stored token, and describes the method's behavior.

SDK authentication documentation update:

* Added a new section for the `auth.logout()` method, including usage instructions, code example, and a description of its functionality in `docs/content/docs/(documentation)/usage/sdk.mdx`.