### PR TITLE
docs: Document data.readOneBy method with usage examples

### DIFF
--- a/docs/content/docs/(documentation)/usage/sdk.mdx
+++ b/docs/content/docs/(documentation)/usage/sdk.mdx
@@ -137,6 +137,35 @@ To retrieve a single record from an entity, use the `readOne` method:
 const { data } = await api.data.readOne("posts", 1);
 ```
 
+### `data.readOneBy([entity], [query])`
+
+To retrieve a single record from an entity using a query (e.g., by a specific field value) instead of an ID, use the `readOneBy` method:
+
+```ts
+const { data } = await api.data.readOneBy("posts", {
+  where: {
+    slug: "hello-world",
+  },
+});
+```
+
+This is useful when you want to find a record by a unique field other than the primary key. You can also use `select`, `with`, and `join` options:
+
+```ts
+const { data } = await api.data.readOneBy("users", {
+  select: ["id", "email", "name"],
+  where: {
+    email: "user@example.com",
+  },
+  with: {
+    posts: {
+      limit: 5,
+    },
+  },
+  join: ["profile"],
+});
+```
+
 ### `data.createOne([entity], [data])`
 
 To create a single record of an entity, use the `createOne` method:


### PR DESCRIPTION
This pull request updates the SDK documentation to introduce and explain the new `readOneBy` method for retrieving a single record by a query instead of just by ID. This addition helps users fetch records using unique fields other than the primary key, and demonstrates advanced usage with options like `select`, `with`, and `join`.

**Documentation improvements:**

* Added a new section describing the `data.readOneBy([entity], [query])` method, including usage examples and explanation of advanced options (`select`, `with`, `join`).