### PR TITLE
feat(plugin/timestamps): add indexStrategy option for entity indexing

### DIFF
--- a/app/src/plugins/data/timestamp.plugin.spec.ts
+++ b/app/src/plugins/data/timestamp.plugin.spec.ts
@@ -71,4 +71,54 @@ describe("timestamps plugin", () => {
       expect(updatedData.updated_at).toBeDefined();
       expect(updatedData.updated_at).toBeInstanceOf(Date);
    });
+
+   test("index strategy", async () => {
+      const app = createApp({
+         config: {
+            data: em({
+               posts: entity("posts", {
+                  title: text(),
+               }),
+            }).toJSON(),
+         },
+         options: {
+            plugins: [timestamps({ entities: ["posts"] })],
+         },
+      });
+      await app.build();
+      expect(app.em.indices.length).toBe(0);
+      {
+         const app = createApp({
+            config: {
+               data: em({
+                  posts: entity("posts", {
+                     title: text(),
+                  }),
+               }).toJSON(),
+            },
+            options: {
+               plugins: [timestamps({ entities: ["posts"], indexStrategy: "composite" })],
+            },
+         });
+         await app.build();
+         expect(app.em.indices.length).toBe(1);
+      }
+
+      {
+         const app = createApp({
+            config: {
+               data: em({
+                  posts: entity("posts", {
+                     title: text(),
+                  }),
+               }).toJSON(),
+            },
+            options: {
+               plugins: [timestamps({ entities: ["posts"], indexStrategy: "individual" })],
+            },
+         });
+         await app.build();
+         expect(app.em.indices.length).toBe(2);
+      }
+   });
 });


### PR DESCRIPTION
Addresses https://github.com/bknd-io/bknd/issues/325, related https://github.com/bknd-io/bknd/pull/326

Introduced a new `indexStrategy` option in the timestamps plugin to configure index generation for `created_at` and `updated_at` fields. Supports "composite" and "individual" strategies for better control over database indexing. Added test coverage for different index strategies.

```ts
import { timestamps } from "bknd/plugins";

export default {
   options: {
      plugins: [
         timestamps({ 
            entities: ["pages"],
            indexStrategy: "composite" // or "individual" to create separate indexes
         })
      ],
   },
} satisfies BkndConfig;
```