### PR TITLE
chore: Update Astro to version 5.16.9 in example package

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -14,7 +14,7 @@
     "@astrojs/react": "^4.2.2",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
-    "astro": "^4.16.16",
+    "astro": "^5.16.9",
     "bknd": "file:../../app",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
This pull request updates the Astro dependency in the `examples/astro/package.json` file to a newer major version. This ensures the example project uses the latest features, bug fixes, and security patches available in Astro v5.

* Dependency update:
  * Upgraded the `astro` package from version `^4.16.16` to `^5.16.9` in `examples/astro/package.json`.