### PR TITLE
add (docs): section for production build issue, React SDK setup

### DIFF
--- a/docs/content/docs/(documentation)/integration/(frameworks)/nextjs.mdx
+++ b/docs/content/docs/(documentation)/integration/(frameworks)/nextjs.mdx
@@ -127,30 +127,79 @@ export const DELETE = handler;
 ```
 
 ## Enabling the Admin UI
+Create a file at `admin/[[...admin]]/page.client.tsx`:
+
+``` tsx title="admin/[[...admin]]/page.client.tsx"
+"use client";
+import dynamic from "next/dynamic";
+
+export const Admin = dynamic(async () => (await import("bknd/ui")).Admin, {
+  ssr: false,
+});
+```
+<Callout type="info">
+  We are using [Colocation](https://nextjs.org/docs/app/getting-started/project-structure#colocation) to prevent server-side hydration error, and the dynamic function to load Admin component only on client side.
+</Callout>
+
 
 Create a page at `admin/[[...admin]]/page.tsx`:
-
 ```tsx title="admin/[[...admin]]/page.tsx"
-import { Admin } from "bknd/ui";
 import { getApi } from "@/bknd";
 import "bknd/dist/styles.css";
+import { Admin } from "./page.client";
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
 
 export default async function AdminPage() {
   // make sure to verify auth using headers
   const api = await getApi({ verify: true });
 
+  // early return if not logged in
+  if (!api.getUser()) {
+    return redirect("/unauthorized");
+  }
+
   return (
-    <Admin
-      withProvider={{ user: api.getUser() }}
-      config={{
-        basepath: "/admin",
-        logo_return_path: "/../",
-        theme: "system",
-      }}
-    />
+    <Suspense>
+      <Admin
+        withProvider={{ user: api.getUser() }}
+        config={{
+          basepath: "/admin",
+          logo_return_path: "/../",
+          theme: "system",
+        }}
+      />
+    </Suspense>
   );
-}
+};
 ```
+
+## React SDK configuration
+
+To use queries and mutation on client side, bknd provides first class support for it with it's [React SDK](/usage/react) 
+to set it up with Next.js add the `ClientProvider` to your root layout
+
+
+```tsx title="app/layout.tsx"
+import { ClientProvider } from "bknd/client";
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <ClientProvider>
+          {children}
+        </ClientProvider>
+      </body>
+    </html>
+  );
+};
+```
+
 
 ## Example usage of the API
 

--- a/docs/content/docs/(documentation)/integration/(frameworks)/nextjs.mdx
+++ b/docs/content/docs/(documentation)/integration/(frameworks)/nextjs.mdx
@@ -71,7 +71,7 @@ export type NextjsBkndConfig<Env = NextjsEnv> = FrameworkBkndConfig<Env> & {
 
 ## Serve the API
 
-Create a helper file to instantiate the bknd instance and retrieve the API, importing the configurationfrom the `bknd.config.ts` file:
+Create a helper file to instantiate the bknd instance and retrieve the API, importing the configuration from the `bknd.config.ts` file:
 
 ```ts title="src/bknd.ts"
 import {
@@ -171,4 +171,27 @@ export default async function Home() {
     </ul>
   );
 }
+```
+
+## Note for Production
+If your admin component is not rendering and has a error like `Identifier 'b' has already been declared`, you will need to add these lines to your `next.config.(mjs|ts)` file:
+
+```ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // ...
+  // for turbopack 
+  experimental: {
+    turbopackMinify: false,
+  },
+
+  // for webpack
+  // webpack: (config) => {
+  //   config.optimization.minimize = false;
+  //   return config;
+  // },
+};
+
+export default nextConfig;
 ```


### PR DESCRIPTION
<img width="1116" height="838" alt="Screenshot_28-Mar_14-36-31_5363" src="https://github.com/user-attachments/assets/5dcb7406-8f86-48f8-a0a1-6e76de117cc8" />

Adds sections to docs for React SDK setup in Next.js and notes for production builds related to issue #369 where admin panel doesn't render in production build of Next.js

Updates to `<Admin />` component usage where the docs now recommend using the `dynamic`  function to load the admin panel only on client side, this also prevent unintended hydration error (like `Date.now` before hydration finishes)