### PR TITLE
Update GitHub Actions to latest versions of dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,15 @@ jobs:
           --health-retries 5
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.3"
 


### PR DESCRIPTION
Update GitHub Actions to use the latest versions of checkout, setup-node, and setup-bun to address deprecated warnings and ensure compatibility with latest GitHub Actions runner.

Warning:
`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, oven-sh/setup-bun@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24.`

For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/