### PR TITLE
Add benchmarking for bun run build process

### DIFF
--- a/app/benchmark/bun-run-build/index.ts
+++ b/app/benchmark/bun-run-build/index.ts
@@ -1,0 +1,51 @@
+/// <reference types="@types/bun" />
+
+import { bench, group } from "mitata";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { runBenchmark, type BenchmarkModule } from "../runner";
+
+const appRoot = join(import.meta.dir, "..", "..");
+const distPath = join(appRoot, "dist");
+
+async function cleanDist() {
+   await rm(distPath, { recursive: true, force: true });
+}
+
+async function runBuild() {
+   await cleanDist();
+
+   const proc = Bun.spawn(["bun", "run", "build"], {
+      cwd: appRoot,
+      env: {
+         ...process.env,
+         NODE_ENV: "production",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+   });
+
+   const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+   ]);
+
+   if (exitCode !== 0) {
+      throw new Error(`bun run build failed with exit code ${exitCode}\n${stdout}\n${stderr}`.trim());
+   }
+   return exitCode;
+}
+
+export const bunRunBuildBenchmark: BenchmarkModule = {
+   id: "bun-run-build",
+   register() {
+      group("bun run build", () => {
+         bench("bun run build", async () => {
+            return await runBuild();
+         });
+      });
+   },
+};
+
+await runBenchmark(bunRunBuildBenchmark);

--- a/app/benchmark/runner.ts
+++ b/app/benchmark/runner.ts
@@ -1,0 +1,11 @@
+import { run } from "mitata";
+
+export type BenchmarkModule = {
+   id: string;
+   register: () => void;
+};
+
+export async function runBenchmark(benchmark: BenchmarkModule) {
+   benchmark.register();
+   await run({ throw: true });
+}

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "build:ci": "mkdir -p dist/static/.vite && echo '{}' > dist/static/.vite/manifest.json && NODE_ENV=production bun run build.ts",
     "build:cli": "bun run build.cli.ts",
     "build:static": "vite build",
-    "benchmark": "bun run benchmark:bun-run-build",
+    "benchmark": "bun add -d mitata",
     "benchmark:bun-run-build": "bun run benchmark/bun-run-build",
     "watch": "bun run build.ts --types --watch",
     "types": "bun tsc -p tsconfig.build.json --noEmit",

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,8 @@
     "build:ci": "mkdir -p dist/static/.vite && echo '{}' > dist/static/.vite/manifest.json && NODE_ENV=production bun run build.ts",
     "build:cli": "bun run build.cli.ts",
     "build:static": "vite build",
+    "benchmark": "bun run benchmark:bun-run-build",
+    "benchmark:bun-run-build": "bun run benchmark/bun-run-build",
     "watch": "bun run build.ts --types --watch",
     "types": "bun tsc -p tsconfig.build.json --noEmit",
     "clean:types": "find ./dist -name '*.d.ts' -delete && rm -f ./dist/tsconfig.tsbuildinfo",

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "app": {
       "name": "bknd",
-      "version": "0.20.0",
+      "version": "0.21.0-rc.1",
       "bin": "./dist/cli/index.js",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
@@ -31,7 +31,7 @@
         "@xyflow/react": "^12.9.2",
         "aws4fetch": "^1.0.20",
         "bcryptjs": "^3.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "fast-xml-parser": "^5.3.1",
         "hono": "4.10.4",
         "json-schema-library": "10.0.0-rc7",
@@ -1812,7 +1812,7 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
-    "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
+    "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 


### PR DESCRIPTION
Introduce a benchmarking module to evaluate the performance of the `bun run build` command. This includes a new script for running benchmarks and updates to the package.json for easy execution.

Example run:
<img width="699" height="162" alt="BKND BENCHMARK" src="https://github.com/user-attachments/assets/f4f218e6-893b-4031-89f3-e479b01d0628" />
