### PR TITLE
fix(tests): resolve prepublishOnly failures in AppAuth and postgres tests

### DIFF
--- a/app/__test__/data/postgres.test.ts
+++ b/app/__test__/data/postgres.test.ts
@@ -41,12 +41,12 @@ describe("postgres", () => {
    beforeAll(async () => {
       if (!(await isPostgresRunning())) {
          await $`docker run --rm --name bknd-test-postgres -d -e POSTGRES_PASSWORD=${credentials.password} -e POSTGRES_USER=${credentials.user} -e POSTGRES_DB=${credentials.database} -p ${credentials.port}:5432 postgres:17`;
-         await $waitUntil("Postgres is running", isPostgresRunning);
+         await $waitUntil("Postgres is running", isPostgresRunning, 500, 20);
          await new Promise((resolve) => setTimeout(resolve, 500));
       }
 
       disableConsoleLog();
-   });
+   }, 30000);
    afterAll(async () => {
       if (await isPostgresRunning()) {
          try {

--- a/app/__test__/modules/AppAuth.spec.ts
+++ b/app/__test__/modules/AppAuth.spec.ts
@@ -149,7 +149,7 @@ describe("AppAuth", () => {
       });
 
       await app.build();
-      app.registerAdminController();
+      app.registerAdminController({ forceDev: true });
       const spy = spyOn(app.module.auth.authenticator, "requestCookieRefresh");
 
       // register custom route


### PR DESCRIPTION
Fixes two test failures that blocked `prepublishOnly`:

**AppAuth spec** — `registerAdminController()` entered prod code path attempting `import("bknd/dist/manifest.json")` which doesn't exist in test env. Pass `forceDev: true` to skip manifest lookup entirely.

**Postgres test** — `beforeAll` hook timed out (5s default) while pulling/starting the postgres:17 Docker container. Bumped `beforeAll` timeout to 30s and increased `$waitUntil` retry window to 500ms × 20 attempts (10s total).

Fixes: https://discord.com/channels/1308395750564302952/1489273855875748081

AppAuth middleware routing, postgres connection test suite.

All 642 bun tests, 54 vitest tests, 5 e2e tests, and full build pipeline pass green.