### PR TITLE
Mysql support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,22 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_PASSWORD: mysql
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_USER: mysql
+          MYSQL_DATABASE: bknd
+          MYSQL_ROOT_HOST: "%"
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     
     steps:
       - uses: actions/checkout@v4

--- a/app/__test__/data/mysql.test.ts
+++ b/app/__test__/data/mysql.test.ts
@@ -1,0 +1,83 @@
+import { describe, beforeAll, afterAll, test } from "bun:test";
+import type { Mysql2Connection } from "data/connection/mysql/Mysql2Connection";
+import { mysql2 } from "bknd";
+import { createPool } from "mysql2";
+import { disableConsoleLog, enableConsoleLog, $waitUntil } from "bknd/utils";
+import { $ } from "bun";
+import { connectionTestSuite } from "data/connection/connection-test-suite";
+import { bunTestRunner } from "adapter/bun/test";
+
+const credentials = {
+   host: "127.0.0.1",
+   port: 3306,
+   user: "mysql",
+   password: "mysql",
+   database: "bknd",
+};
+
+async function cleanDatabase(connection: InstanceType<typeof Mysql2Connection>) {
+   const kysely = connection.kysely;
+
+   const tables = await kysely.introspection.getTables();
+   for (const table of tables) {
+      await kysely.schema.dropTable(table.name).ifExists().execute();
+   }
+}
+
+async function isMySqlRunning() {
+   try {
+      // Try to actually connect to MySql
+      const conn = mysql2({ pool: createPool(credentials) });
+         await conn.ping();
+         await conn.close();
+      return true;
+   } catch (e) {
+      return false;
+   }
+}
+
+describe("mysql", () => {
+   beforeAll(async () => {
+      if (!(await isMySqlRunning())) {
+         await $`docker run --rm --name bknd-test-mysql -d -e MYSQL_ROOT_PASSWORD=${credentials.password} -e MYSQL_USER=${credentials.user} -e MYSQL_PASSWORD=${credentials.password} -e MYSQL_DATABASE=${credentials.database} -e MYSQL_ROOT_HOST=${credentials.host} -p ${credentials.port}:3306 mysql:8`;
+
+         await $waitUntil("MySql is running", isMySqlRunning, 500, 40);
+         await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      disableConsoleLog();
+   }, 120000);
+   afterAll(async () => {
+      if (await isMySqlRunning()) {
+         try {
+            await $`docker stop bknd-test-mysql`;
+         } catch (e) { }
+      }
+
+      enableConsoleLog();
+   });
+
+   describe.serial.each([
+      ["mysql2", () => mysql2({ pool: createPool(credentials) })]])("%s", (name, createConnection) => {
+         connectionTestSuite(
+            {
+               ...bunTestRunner,
+               test: test.serial,
+            },
+            {
+               makeConnection: () => {
+                  const connection = createConnection();
+                  return {
+                     connection,
+                     dispose: async () => {
+                        await cleanDatabase(connection);
+                        await connection.close();
+                     },
+                  };
+               },
+               rawDialectDetails: [],
+               disableConsoleLog: false,
+            },
+         );
+      });
+});

--- a/app/__test__/data/mysql.test.ts
+++ b/app/__test__/data/mysql.test.ts
@@ -9,7 +9,7 @@ import { bunTestRunner } from "adapter/bun/test";
 
 const credentials = {
    host: "127.0.0.1",
-   port: 3306,
+   port: 3307,
    user: "mysql",
    password: "mysql",
    database: "bknd",

--- a/app/__test__/data/specs/fields/JsonField.spec.ts
+++ b/app/__test__/data/specs/fields/JsonField.spec.ts
@@ -8,7 +8,7 @@ describe("[data] JsonField", async () => {
    fieldTestSuite(bunTestRunner, JsonField, {
       defaultValue: { a: 1 },
       //sampleValues: ["string", { test: 1 }, 1],
-      schemaType: "text",
+      schemaType: "json",
    });
 
    test("transformPersist (no config)", async () => {

--- a/app/__test__/data/specs/fields/JsonSchemaField.spec.ts
+++ b/app/__test__/data/specs/fields/JsonSchemaField.spec.ts
@@ -4,7 +4,7 @@ import { fieldTestSuite } from "data/fields/field-test-suite";
 
 describe("[data] JsonSchemaField", async () => {
    // @ts-ignore
-   fieldTestSuite({ expect, test }, JsonSchemaField, { defaultValue: {}, schemaType: "text" });
+   fieldTestSuite({ expect, test }, JsonSchemaField, { defaultValue: {}, schemaType: "json" });
 
    // @todo: add JsonSchemaField tests
 });

--- a/app/package.json
+++ b/app/package.json
@@ -68,6 +68,7 @@
     "jsonv-ts": "^0.10.1",
     "kysely": "0.28.8",
     "lodash-es": "^4.17.21",
+    "mysql2": "^3.21.1",
     "oauth4webapi": "^2.11.1",
     "object-path-immutable": "^4.1.2",
     "picocolors": "^1.1.1",

--- a/app/src/data/connection/Connection.ts
+++ b/app/src/data/connection/Connection.ts
@@ -90,15 +90,17 @@ const CONN_SYMBOL = Symbol.for("bknd:connection");
 export type Features = {
    batching: boolean;
    softscans: boolean;
+   returning: boolean;
 };
 
 export abstract class Connection<Client = unknown> {
    abstract name: string;
    protected initialized = false;
    protected pluginRunner: KyselyPluginRunner;
-   protected readonly supported: Partial<Features> = {
+   protected readonly supported: Features = {
       batching: false,
       softscans: true,
+      returning: false,
    };
    kysely: Kysely<DB>;
    client!: Client;

--- a/app/src/data/connection/mysql/Mysql2Connection.ts
+++ b/app/src/data/connection/mysql/Mysql2Connection.ts
@@ -1,0 +1,38 @@
+import {
+   Kysely,
+   MysqlDialect,
+   type MysqlDialectConfig as KyselyMysqlDialectDialectConfig,
+} from "kysely";
+import { MysqlIntrospector } from "./MysqlIntrospector";
+import { MysqlConnection, plugins } from "./MysqlConnection";
+import { customIntrospector } from "../Connection";
+import type { Pool } from "mysql2";
+
+export type MysqlDialectConfig = Omit<KyselyMysqlDialectDialectConfig, "pool"> & {
+   pool: Pool;
+};
+
+export class Mysql2Connection extends MysqlConnection<Pool> {
+   override name = "mysql2";
+
+   constructor(config: MysqlDialectConfig) {
+      const kysely = new Kysely({
+         dialect: customIntrospector(MysqlDialect, MysqlIntrospector, {
+            excludeTables: [],
+            // casting type because the types in mysql2 and mysql2/promise are different
+         }).create(config as KyselyMysqlDialectDialectConfig),
+         plugins,
+      });
+
+      super(kysely);
+      this.client = config.pool;
+   }
+
+   override async close(): Promise<void> {
+      await this.client.end();
+   }
+}
+
+export function mysql2(config: MysqlDialectConfig): Mysql2Connection {
+   return new Mysql2Connection(config);
+}

--- a/app/src/data/connection/mysql/MysqlConnection.ts
+++ b/app/src/data/connection/mysql/MysqlConnection.ts
@@ -1,0 +1,87 @@
+import {
+   Connection,
+   type DbFunctions,
+   type FieldSpec,
+   type SchemaResponse,
+   type ConnQuery,
+   type ConnQueryResults,
+} from "../Connection";
+import {
+   ParseJSONResultsPlugin,
+   type ColumnDataType,
+   type ColumnDefinitionBuilder,
+   type Kysely,
+   type KyselyPlugin,
+   type SelectQueryBuilder,
+} from "kysely";
+import { jsonArrayFrom, jsonBuildObject, jsonObjectFrom } from "kysely/helpers/mysql";
+
+export type QB = SelectQueryBuilder<any, any, any>;
+
+export const plugins = [new ParseJSONResultsPlugin()];
+
+export abstract class MysqlConnection<Client = unknown> extends Connection<Client> {
+   protected override readonly supported = {
+      // batching: true,
+      // softscans: true,
+   };
+
+   constructor(kysely: Kysely<any>, fn?: Partial<DbFunctions>, _plugins?: KyselyPlugin[]) {
+      super(
+         kysely,
+         fn ?? {
+            jsonArrayFrom,
+            jsonBuildObject,
+            jsonObjectFrom,
+         },
+         _plugins ?? plugins,
+      );
+   }
+
+   override getFieldSchema(spec: FieldSpec): SchemaResponse {
+      this.validateFieldSpecType(spec.type);
+      let type: ColumnDataType = spec.type;
+
+      if (spec.primary) {
+         if (spec.type === "integer") {
+            type = "serial";
+         }
+      }
+
+      switch (spec.type) {
+         case "blob":
+            type = "bytea";
+            break;
+         case "date":
+         case "datetime":
+            type = "timestamp";
+            break;
+         case "text":
+            type = "varchar";
+            break;
+      }
+
+      return [
+         spec.name,
+         type,
+         (col: ColumnDefinitionBuilder) => {
+            if (spec.primary) {
+               return col.primaryKey().notNull();
+            }
+            if (spec.references) {
+               return col
+                  .references(spec.references)
+                  .onDelete(spec.onDelete ?? "set null")
+                  .onUpdate(spec.onUpdate ?? "no action");
+            }
+            return col;
+         },
+      ];
+   }
+
+   override async executeQueries<O extends ConnQuery[]>(...qbs: O): Promise<ConnQueryResults<O>> {
+      return this.kysely.transaction().execute(async (trx) => {
+         return Promise.all(qbs.map((q) => trx.executeQuery(q)));
+      }) as any;
+   }
+}

--- a/app/src/data/connection/mysql/MysqlConnection.ts
+++ b/app/src/data/connection/mysql/MysqlConnection.ts
@@ -5,6 +5,7 @@ import {
    type SchemaResponse,
    type ConnQuery,
    type ConnQueryResults,
+   type Features,
 } from "../Connection";
 import {
    ParseJSONResultsPlugin,
@@ -15,15 +16,17 @@ import {
    type SelectQueryBuilder,
 } from "kysely";
 import { jsonArrayFrom, jsonBuildObject, jsonObjectFrom } from "kysely/helpers/mysql";
+import type { Field } from "data/fields/Field";
 
 export type QB = SelectQueryBuilder<any, any, any>;
 
 export const plugins = [new ParseJSONResultsPlugin()];
 
 export abstract class MysqlConnection<Client = unknown> extends Connection<Client> {
-   protected override readonly supported = {
-      // batching: true,
-      // softscans: true,
+   protected override readonly supported: Features = {
+      batching: false,
+      softscans: true,
+      returning: false,
    };
 
    constructor(kysely: Kysely<any>, fn?: Partial<DbFunctions>, _plugins?: KyselyPlugin[]) {
@@ -50,14 +53,14 @@ export abstract class MysqlConnection<Client = unknown> extends Connection<Clien
 
       switch (spec.type) {
          case "blob":
-            type = "bytea";
+            type = "blob";
             break;
          case "date":
          case "datetime":
             type = "timestamp";
             break;
          case "text":
-            type = "varchar";
+            type = "varchar(255)";
             break;
       }
 
@@ -77,6 +80,23 @@ export abstract class MysqlConnection<Client = unknown> extends Connection<Clien
             return col;
          },
       ];
+   }
+
+   override toDriver(value: unknown, field: Field): unknown {
+      if (
+         ((field.schema && field.schema()?.type === "date") ||
+            (field.schema && field.schema()?.type === "datetime") ||
+            (field.schema && field.schema()?.type === "timestamp")) &&
+         value
+      ) {
+         if (value instanceof Date) {
+            return value.toISOString().slice(0, 19).replace("T", " ");
+         }
+         if (typeof value === "string" && value.includes("T") && value.endsWith("Z")) {
+            return value.slice(0, 19).replace("T", " ");
+         }
+      }
+      return super.toDriver(value, field);
    }
 
    override async executeQueries<O extends ConnQuery[]>(...qbs: O): Promise<ConnQueryResults<O>> {

--- a/app/src/data/connection/mysql/MysqlIntrospector.ts
+++ b/app/src/data/connection/mysql/MysqlIntrospector.ts
@@ -1,0 +1,119 @@
+import { type SchemaMetadata, sql } from "kysely";
+import { BaseIntrospector } from "../BaseIntrospector";
+
+type MySqlSchemaSpec = {
+   name: string;
+   type: "VIEW" | "BASE TABLE";
+   columns: {
+      name: string;
+      type: string;
+      notnull: number;
+      dflt: string;
+      pk: boolean;
+      auto: number;
+   }[];
+   indices: {
+      name: string;
+      non_unique: number;
+      columns: { name: string; seqno: number }[];
+   }[];
+};
+
+export class MysqlIntrospector extends BaseIntrospector {
+   async getSchemas(): Promise<SchemaMetadata[]> {
+      const rawSchemas = await this.db
+         .selectFrom("information_schema.schemata")
+         .select("schema_name as nspname")
+         .$castTo<{ nspname: string }>()
+         .execute();
+
+      return rawSchemas.map((it) => ({ name: it.nspname }));
+   }
+
+   async getSchemaSpec() {
+      const query = sql`
+         WITH tables_and_views AS (
+            SELECT 
+               TABLE_NAME AS name,
+               TABLE_TYPE AS type
+            FROM information_schema.tables
+            WHERE TABLE_SCHEMA = DATABASE() -- Or a specific schema name
+            AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+            AND TABLE_NAME NOT IN (${this.getExcludedTableNames().join(", ")})
+         ),
+         columns_info AS (
+            SELECT 
+               TABLE_NAME AS name,
+               JSON_ARRAYAGG(JSON_OBJECT(
+                  'name', COLUMN_NAME,
+                  'type', DATA_TYPE,
+                  'notnull', (CASE WHEN IS_NULLABLE = 'NO' THEN 1 ELSE 0 END),
+                  'dflt', COLUMN_DEFAULT,
+                  'pk', (CASE WHEN COLUMN_KEY = 'PRI' THEN 1 ELSE 0 END),
+                  'auto', (CASE WHEN EXTRA = 'auto_increment' THEN 1 ELSE 0 END)
+               )) AS columns
+            FROM information_schema.columns
+            WHERE TABLE_SCHEMA = DATABASE()
+            GROUP BY TABLE_NAME
+         ),
+         indices_info AS (
+            SELECT 
+               TABLE_NAME AS table_name,
+               JSON_OBJECT(
+                  'name', INDEX_NAME,
+                  'non_unique', MAX(NON_UNIQUE),
+                  'columns', (
+                     SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                        'name', COLUMN_NAME,
+                        'seqno', SEQ_IN_INDEX
+                     ))
+                     FROM information_schema.statistics s2
+                     WHERE s2.TABLE_NAME = s1.TABLE_NAME 
+                     AND s2.INDEX_NAME = s1.INDEX_NAME
+                     AND s2.TABLE_SCHEMA = s1.TABLE_SCHEMA
+                  )
+               ) AS index_obj
+            FROM information_schema.statistics s1
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND INDEX_NAME != 'PRIMARY'
+            GROUP BY TABLE_NAME, INDEX_NAME
+         )
+         SELECT 
+            tv.name,
+            tv.type,
+            ci.columns,
+            ii.indices
+         FROM tables_and_views tv
+         LEFT JOIN columns_info ci ON tv.name = ci.name
+         LEFT JOIN (
+            SELECT table_name, JSON_ARRAYAGG(index_obj) as indices 
+            FROM indices_info
+            GROUP BY table_name
+         ) ii ON tv.name = ii.table_name;
+      `;
+
+      const tables = await this.executeWithPlugins<MySqlSchemaSpec[]>(query);
+
+      return tables.map((table) => ({
+         name: table.name,
+         isView: table.type === "VIEW",
+         columns: table.columns.map((col) => ({
+            name: col.name,
+            dataType: col.type,
+            isNullable: !col.notnull,
+            isAutoIncrementing: col.auto === 1,
+            hasDefaultValue: col.dflt != null,
+            comment: undefined,
+         })),
+         indices: (table.indices || []).map((index) => ({
+            name: index.name,
+            table: table.name,
+            isUnique: index.non_unique === 0,
+            columns: index.columns.map((col) => ({
+               name: col.name,
+               order: col.seqno - 1,
+            })),
+         })),
+      }));
+   }
+}

--- a/app/src/data/connection/mysql/MysqlIntrospector.ts
+++ b/app/src/data/connection/mysql/MysqlIntrospector.ts
@@ -105,15 +105,22 @@ export class MysqlIntrospector extends BaseIntrospector {
             hasDefaultValue: col.dflt != null,
             comment: undefined,
          })),
-         indices: (table.indices || []).map((index) => ({
-            name: index.name,
-            table: table.name,
-            isUnique: index.non_unique === 0,
-            columns: index.columns.map((col) => ({
-               name: col.name,
-               order: col.seqno - 1,
+         indices: (table.indices || [])
+            .filter((index) => {
+               if (index.name === "PRIMARY") return false;
+               const pkCol = table.columns.find((c) => c.pk && c.name === index.name);
+               if (pkCol && index.non_unique === 0) return false;
+               return true;
+            })
+            .map((index) => ({
+               name: index.name,
+               table: table.name,
+               isUnique: index.non_unique === 0,
+               columns: index.columns.map((col) => ({
+                  name: col.name,
+                  order: col.seqno - 1,
+               })),
             })),
-         })),
       }));
    }
 }

--- a/app/src/data/connection/mysql/custom.ts
+++ b/app/src/data/connection/mysql/custom.ts
@@ -1,0 +1,46 @@
+import { customIntrospector, type DbFunctions } from "../Connection";
+import { Kysely, type Dialect, type KyselyPlugin } from "kysely";
+import { plugins, MysqlConnection } from "./MysqlConnection";
+import { MysqlIntrospector } from "./MysqlIntrospector";
+
+export type Constructor<T> = new (...args: any[]) => T;
+
+export type CustomMysqlConnection = {
+   supports?: Partial<MysqlConnection["supported"]>;
+   fn?: Partial<DbFunctions>;
+   plugins?: KyselyPlugin[];
+   excludeTables?: string[];
+};
+
+export function createCustomMySqlConnection<
+   T extends Constructor<Dialect>,
+   C extends ConstructorParameters<T>[0],
+>(
+   name: string,
+   dialect: Constructor<Dialect>,
+   options?: CustomMysqlConnection,
+): (config: C) => MysqlConnection {
+   const supported = {
+      batching: true,
+      ...((options?.supports ?? {}) as any),
+   };
+
+   return (config: C) =>
+      new (class extends MysqlConnection {
+         override name = name;
+         override readonly supported = supported;
+
+         constructor(config: C) {
+            super(
+               new Kysely({
+                  dialect: customIntrospector(dialect, MysqlIntrospector, {
+                     excludeTables: options?.excludeTables ?? [],
+                  }).create(config),
+                  plugins: options?.plugins ?? plugins,
+               }),
+               options?.fn,
+               options?.plugins,
+            );
+         }
+      })(config);
+}

--- a/app/src/data/connection/postgres/PostgresConnection.ts
+++ b/app/src/data/connection/postgres/PostgresConnection.ts
@@ -5,6 +5,7 @@ import {
    type SchemaResponse,
    type ConnQuery,
    type ConnQueryResults,
+   type Features,
 } from "../Connection";
 import {
    ParseJSONResultsPlugin,
@@ -21,9 +22,10 @@ export type QB = SelectQueryBuilder<any, any, any>;
 export const plugins = [new ParseJSONResultsPlugin()];
 
 export abstract class PostgresConnection<Client = unknown> extends Connection<Client> {
-   protected override readonly supported = {
+   protected override readonly supported: Features = {
       batching: true,
       softscans: true,
+      returning: true,
    };
 
    constructor(kysely: Kysely<any>, fn?: Partial<DbFunctions>, _plugins?: KyselyPlugin[]) {

--- a/app/src/data/connection/sqlite/SqliteConnection.ts
+++ b/app/src/data/connection/sqlite/SqliteConnection.ts
@@ -7,7 +7,7 @@ import {
    type KyselyPlugin,
 } from "kysely";
 import { jsonArrayFrom, jsonBuildObject, jsonObjectFrom } from "kysely/helpers/sqlite";
-import { Connection, type DbFunctions, type FieldSpec, type SchemaResponse } from "../Connection";
+import { Connection, type DbFunctions, type FieldSpec, type SchemaResponse, type Features } from "../Connection";
 import type { Constructor } from "core/registry/Registry";
 import { customIntrospector } from "../Connection";
 import { SqliteIntrospector } from "./SqliteIntrospector";
@@ -31,6 +31,11 @@ export type SqliteConnectionConfig<
 
 export abstract class SqliteConnection<Client = unknown> extends Connection<Client> {
    override name = "sqlite";
+   protected override readonly supported: Features = {
+      returning: true,
+      batching: false,
+      softscans: true,
+   };
 
    constructor(config: SqliteConnectionConfig) {
       const { excludeTables, additionalPlugins } = config;

--- a/app/src/data/entities/mutation/Mutator.ts
+++ b/app/src/data/entities/mutation/Mutator.ts
@@ -153,12 +153,27 @@ export class Mutator<
          };
       }
 
-      const query = this.conn
-         .insertInto(entity.name)
-         .values(validatedData)
-         .returning(entity.getSelect());
+      let query: any = this.conn.insertInto(entity.name).values(validatedData);
+
+      if (this.em.connection.supports("returning")) {
+         query = query.returning(entity.getSelect());
+      }
 
       const res = await this.performQuery(query, { single: true });
+
+      if (!this.em.connection.supports("returning")) {
+         const primary = entity.getPrimaryField();
+         // @ts-ignore
+         const id = res.first().insertId ?? validatedData[primary.name];
+         if (id) {
+            const fetchQuery = this.conn.selectFrom(entity.name).selectAll().where(primary.name, "=", id);
+            const fetchResult = await this.em.connection.executeQuery(fetchQuery);
+            // @ts-ignore
+            res.results[0].rows = fetchResult.rows;
+            // @ts-ignore
+            res.results[0].data = this.em.hydrate(entity.name, fetchResult.rows as any);
+         }
+      }
 
       await this.emgr.emit(
          new Mutator.Events.MutatorInsertAfter({ entity, data: res.data, changed: validatedData }),
@@ -184,13 +199,25 @@ export class Mutator<
       const _data = result.returned ? result.params.data : data;
       const validatedData = await this.getValidatedData(_data, "update");
 
-      const query = this.conn
+      let query: any = this.conn
          .updateTable(entity.name)
          .set(validatedData as any)
-         .where(entity.id().name, "=", id)
-         .returning(entity.getSelect());
+         .where(entity.id().name, "=", id);
+
+      if (this.em.connection.supports("returning")) {
+         query = query.returning(entity.getSelect());
+      }
 
       const res = await this.performQuery(query, { single: true });
+
+      if (!this.em.connection.supports("returning")) {
+         const fetchQuery = this.conn.selectFrom(entity.name).selectAll().where(entity.id().name, "=", id);
+         const fetchResult = await this.em.connection.executeQuery(fetchQuery);
+         // @ts-ignore
+         res.results[0].rows = fetchResult.rows;
+         // @ts-ignore
+         res.results[0].data = this.em.hydrate(entity.name, fetchResult.rows as any);
+      }
 
       await this.emgr.emit(
          new Mutator.Events.MutatorUpdateAfter({
@@ -212,12 +239,25 @@ export class Mutator<
 
       await this.emgr.emit(new Mutator.Events.MutatorDeleteBefore({ entity, entityId: id }));
 
-      const query = this.conn
-         .deleteFrom(entity.name)
-         .where(entity.id().name, "=", id)
-         .returning(entity.getSelect());
+      let query: any = this.conn.deleteFrom(entity.name).where(entity.id().name, "=", id);
+
+      let rows: any[] = [];
+      if (!this.em.connection.supports("returning")) {
+         const fetchQuery = this.conn.selectFrom(entity.name).selectAll().where(entity.id().name, "=", id);
+         const fetchResult = await this.em.connection.executeQuery(fetchQuery);
+         rows = fetchResult.rows;
+      } else {
+         query = query.returning(entity.getSelect());
+      }
 
       const res = await this.performQuery(query, { single: true });
+
+      if (!this.em.connection.supports("returning")) {
+         // @ts-ignore
+         res.results[0].rows = rows;
+         // @ts-ignore
+         res.results[0].data = this.em.hydrate(entity.name, rows as any);
+      }
 
       await this.emgr.emit(
          new Mutator.Events.MutatorDeleteAfter({ entity, entityId: id, data: res.data }),
@@ -278,9 +318,11 @@ export class Mutator<
          throw new Error("Where clause must be provided for mass deletion");
       }
 
-      const qb = this.appendWhere(this.conn.deleteFrom(entity.name), where).returning(
-         entity.getSelect(),
-      );
+      let qb: any = this.appendWhere(this.conn.deleteFrom(entity.name), where);
+
+      if (this.em.connection.supports("returning")) {
+         qb = qb.returning(entity.getSelect());
+      }
 
       return await this.performQuery(qb);
    }
@@ -297,9 +339,12 @@ export class Mutator<
          throw new Error("Where clause must be provided for mass update");
       }
 
-      const query = this.appendWhere(this.conn.updateTable(entity.name), where)
-         .set(validatedData as any)
-         .returning(entity.getSelect());
+      let query: any = this.appendWhere(this.conn.updateTable(entity.name), where)
+         .set(validatedData as any);
+
+      if (this.em.connection.supports("returning")) {
+         query = query.returning(entity.getSelect());
+      }
 
       return await this.performQuery(query);
    }
@@ -331,11 +376,36 @@ export class Mutator<
          validated.push(validatedData);
       }
 
-      const query = this.conn
+      let query: any = this.conn
          .insertInto(entity.name)
-         .values(validated)
-         .returning(entity.getSelect());
+         .values(validated);
 
-      return await this.performQuery(query);
+      if (this.em.connection.supports("returning")) {
+         query = query.returning(entity.getSelect());
+      }
+
+      const res = await this.performQuery(query);
+
+      if (!this.em.connection.supports("returning")) {
+         // @ts-ignore
+         const firstId = res.first().insertId;
+         if (firstId) {
+            const primary = entity.getPrimaryField();
+            const fetchQuery = this.conn
+               .selectFrom(entity.name)
+               .selectAll()
+               .where(primary.name, ">=", firstId)
+               .orderBy(primary.name, "asc")
+               .limit(data.length);
+
+            const fetchResult = await this.em.connection.executeQuery(fetchQuery);
+            // @ts-ignore
+            res.results[0].rows = fetchResult.rows;
+            // @ts-ignore
+            res.results[0].data = this.em.hydrate(entity.name, fetchResult.rows as any);
+         }
+      }
+
+      return res;
    }
 }

--- a/app/src/data/fields/DateField.ts
+++ b/app/src/data/fields/DateField.ts
@@ -65,7 +65,7 @@ export class DateField<Required extends true | false = false> extends Field<
       if (context === "submit") {
          try {
             return date.toISOString();
-         } catch (e) {
+         } catch (_) {
             return undefined;
          }
       }
@@ -73,8 +73,8 @@ export class DateField<Required extends true | false = false> extends Field<
       if (this.config.type === "week") {
          try {
             return `${date.getFullYear()}-W${dayjs(date).week()}`;
-         } catch (e) {
-            $console.warn("DateField.getValue:week error", value, String(e));
+         } catch (_) {
+            $console.warn("DateField.getValue:week error", value);
             return;
          }
       }
@@ -86,8 +86,8 @@ export class DateField<Required extends true | false = false> extends Field<
          const local = new Date(date.getTime() - offset * 60000);
 
          return this.formatDate(local);
-      } catch (e) {
-         $console.warn("DateField.getValue error", this.config.type, value, String(e));
+      } catch (_) {
+         $console.warn("DateField.getValue error", this.config.type, value);
          return;
       }
    }
@@ -111,7 +111,7 @@ export class DateField<Required extends true | false = false> extends Field<
 
       try {
          return new Date(value);
-      } catch (e) {
+      } catch (_) {
          return null;
       }
    }

--- a/app/src/data/fields/EnumField.ts
+++ b/app/src/data/fields/EnumField.ts
@@ -48,6 +48,14 @@ export class EnumField<Required extends true | false = false, TypeOverride = str
       return enumFieldConfigSchema;
    }
 
+   // prevent runtime mutation
+   override schema() {
+      return Object.freeze({
+         ...super.schema()!,
+         type: "text",
+      });
+   }
+
    getOptions(): { label: string; value: string }[] {
       const options = this.config?.options ?? { type: "strings", values: [] };
 

--- a/app/src/data/fields/JsonField.ts
+++ b/app/src/data/fields/JsonField.ts
@@ -25,6 +25,13 @@ export class JsonField<Required extends true | false = false, TypeOverride = obj
       return jsonFieldConfigSchema;
    }
 
+   override schema() {
+      return Object.freeze({
+         ...super.schema()!,
+         type: "json",
+      });
+   }
+
    /**
     * Transform value after retrieving from database
     * @param value

--- a/app/src/data/fields/JsonSchemaField.ts
+++ b/app/src/data/fields/JsonSchemaField.ts
@@ -38,6 +38,13 @@ export class JsonSchemaField<
       return jsonSchemaFieldConfigSchema;
    }
 
+   override schema() {
+      return Object.freeze({
+         ...super.schema()!,
+         type: "json",
+      });
+   }
+
    getJsonSchema(): JsonSchema {
       return this.config?.schema as JsonSchema;
    }

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -155,6 +155,9 @@ export { SqliteLocalConnection } from "data/connection/sqlite/SqliteLocalConnect
 // data sqlocal
 export { SQLocalConnection, sqlocal } from "data/connection/sqlite/sqlocal/SQLocalConnection";
 
+// data mysql
+export { Mysql2Connection, mysql2 } from "data/connection/mysql/Mysql2Connection";
+
 // data postgres
 export {
    pg,


### PR DESCRIPTION
Add database adapter for mysql using the mysql2 client and kysley dialect 

A large amount of files are modified because mysql doesn't support various features from pg/sqlite (like the returning statement) update are made accordingly 

Includes:
- Test suite (updates github actions)
- Package exports and types
