### PR TITLE
add support for custom user defined primary key

### DIFF
--- a/app/__test__/data/specs/Entity.spec.ts
+++ b/app/__test__/data/specs/Entity.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Entity } from "data/entities";
-import { NumberField, TextField } from "data/fields";
+import { NumberField, TextField, PrimaryField } from "data/fields";
 
 describe("[data] Entity", async () => {
    const entity = new Entity("test", [
@@ -46,5 +46,17 @@ describe("[data] Entity", async () => {
       const field = new TextField("new_field");
       entity.addField(field);
       expect(entity.getField("new_field")).toBe(field);
+   });
+
+   test("custom primary", async () => {
+      const customPrimaryEntity = new Entity("custom", [
+         new PrimaryField("custom", { format: "uuid" }),
+         new TextField("name"),
+      ]);
+
+      expect(customPrimaryEntity.getPrimaryField().name).toEqual("custom");
+      expect(customPrimaryEntity.getPrimaryField().format).toEqual("uuid");
+      expect(customPrimaryEntity.getSelect()).toEqual(["custom", "name"]);
+      expect(customPrimaryEntity.getField("id")).toBeUndefined(); // no auto id
    });
 });

--- a/app/__test__/data/specs/fields/PrimaryField.spec.ts
+++ b/app/__test__/data/specs/fields/PrimaryField.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { PrimaryField } from "data/fields";
 
 describe("[data] PrimaryField", async () => {
-   const field = new PrimaryField("primary");
+   const field = new PrimaryField("primary", { fillable: false });
 
    test("name", async () => {
       expect(field.name).toBe("primary");
@@ -24,7 +24,7 @@ describe("[data] PrimaryField", async () => {
    });
 
    test("isFillable", async () => {
-      expect(field.isFillable()).toBe(true);
+      expect(field.isFillable()).toBe(false);
    });
 
    test("isHidden", async () => {
@@ -36,7 +36,7 @@ describe("[data] PrimaryField", async () => {
    });
 
    test("transformPersist/Retrieve", async () => {
-      expect(field.transformPersist(1)).resolves.toBe(1);
+      expect(field.transformPersist(1)).rejects.toThrow();
       expect(field.transformRetrieve(1)).toBe(1);
    });
 

--- a/app/__test__/data/specs/fields/PrimaryField.spec.ts
+++ b/app/__test__/data/specs/fields/PrimaryField.spec.ts
@@ -24,7 +24,7 @@ describe("[data] PrimaryField", async () => {
    });
 
    test("isFillable", async () => {
-      expect(field.isFillable()).toBe(false);
+      expect(field.isFillable()).toBe(true);
    });
 
    test("isHidden", async () => {
@@ -36,7 +36,7 @@ describe("[data] PrimaryField", async () => {
    });
 
    test("transformPersist/Retrieve", async () => {
-      expect(field.transformPersist(1)).rejects.toThrow();
+      expect(field.transformPersist(1)).resolves.toBe(1);
       expect(field.transformRetrieve(1)).toBe(1);
    });
 

--- a/app/src/data/entities/Entity.ts
+++ b/app/src/data/entities/Entity.ts
@@ -171,7 +171,7 @@ export class Entity<
    }
 
    getPrimaryField(): PrimaryField {
-      return this.fields[0] as PrimaryField;
+      return this.fields.find((field) => field.type === "primary") as PrimaryField;
    }
 
    id(): PrimaryField {

--- a/app/src/data/entities/Entity.ts
+++ b/app/src/data/entities/Entity.ts
@@ -15,7 +15,7 @@ export const entityConfigSchema = s
          name: s.string(),
          name_singular: s.string(),
          description: s.string(),
-         sort_field: s.string({ default: config.data.default_primary_field }),
+         sort_field: s.string(),
          sort_dir: s.string({ enum: ["asc", "desc"], default: "asc" }),
          primary_format: s.string({ enum: primaryFieldTypes }),
       },
@@ -82,6 +82,10 @@ export class Entity<
          fields.forEach((field) => this.addField(field));
       }
 
+      if (!this.config.sort_field) {
+         this.config.sort_field = this.getPrimaryField().name;
+      }
+
       if (type) this.type = type;
       this[ENTITY_SYMBOL] = true;
    }
@@ -115,7 +119,7 @@ export class Entity<
 
    getDefaultSort() {
       return {
-         by: this.config.sort_field ?? "id",
+         by: this.config.sort_field ?? this.getPrimaryField().name,
          dir: this.config.sort_dir ?? "asc",
       };
    }

--- a/app/src/data/fields/PrimaryField.ts
+++ b/app/src/data/fields/PrimaryField.ts
@@ -24,7 +24,11 @@ export class PrimaryField<Required extends true | false = false> extends Field<
    override readonly type = "primary";
 
    constructor(name: string = config.data.default_primary_field, cfg?: PrimaryFieldConfig) {
-      super(name, { ...cfg, fillable: false, required: false });
+      super(name, {
+         ...cfg,
+         fillable: cfg?.fillable ?? name !== config.data.default_primary_field,
+         required: false,
+      });
    }
 
    override isRequired(): boolean {
@@ -60,7 +64,13 @@ export class PrimaryField<Required extends true | false = false> extends Field<
       return undefined;
    }
 
-   override async transformPersist(value: any): Promise<number> {
+   override async transformPersist(value: any): Promise<any> {
+      if (this.isFillable()) {
+         if (value == null) {
+            return this.getNewValue();
+         }
+         return value;
+      }
       throw new Error("PrimaryField: This function should not be called");
    }
 

--- a/app/src/data/prototype/index.ts
+++ b/app/src/data/prototype/index.ts
@@ -77,7 +77,7 @@ export class FieldPrototype {
       public type: TFieldType,
       public config: any,
       public is_required: boolean,
-   ) { }
+   ) {}
 
    required() {
       this.is_required = true;
@@ -305,8 +305,8 @@ class EntityManagerPrototype<Entities extends Record<string, Entity>> extends En
 
 type Chained<R extends Record<string, (...args: any[]) => any>> = {
    [K in keyof R]: R[K] extends (...args: any[]) => any
-   ? (...args: Parameters<R[K]>) => Chained<R>
-   : never;
+      ? (...args: Parameters<R[K]>) => Chained<R>
+      : never;
 };
 type ChainedFn<
    Fn extends (...args: any[]) => Record<string, (...args: any[]) => any>,
@@ -365,22 +365,22 @@ export function em<Entities extends Record<string, Entity>>(
 
 export type InferEntityFields<T> = T extends Entity<infer _N, infer Fields>
    ? {
-      [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
-      ? Required extends true
-      ? Type
-      : Type | undefined
-      : never;
-   }
+        [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
+           ? Required extends true
+              ? Type
+              : Type | undefined
+           : never;
+     }
    : never;
 
 export type InferFields<Fields> = Fields extends Record<string, Field<any, any, any>>
    ? {
-      [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
-      ? Required extends true
-      ? Type
-      : Type | undefined
-      : never;
-   }
+        [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
+           ? Required extends true
+              ? Type
+              : Type | undefined
+           : never;
+     }
    : never;
 
 type Prettify<T> = {
@@ -396,10 +396,10 @@ type OptionalUndefined<
    T,
    Props extends keyof T = keyof T,
    OptionsProps extends keyof T = Props extends keyof T
-   ? undefined extends T[Props]
-   ? Props
-   : never
-   : never,
+      ? undefined extends T[Props]
+         ? Props
+         : never
+      : never,
 > = Merge<
    {
       [K in OptionsProps]?: T[K];
@@ -410,8 +410,8 @@ type OptionalUndefined<
 
 export type InferField<Field> = Field extends { _type: infer Type; _required: infer Required }
    ? Required extends true
-   ? Type
-   : Type | undefined
+      ? Type
+      : Type | undefined
    : never;
 
 export type Schemas<T extends Record<string, Entity>> = {

--- a/app/src/data/prototype/index.ts
+++ b/app/src/data/prototype/index.ts
@@ -21,6 +21,8 @@ import {
    type NumberFieldConfig,
    TextField,
    type TextFieldConfig,
+   PrimaryField,
+   type PrimaryFieldConfig,
 } from "data/fields";
 
 import { Entity, type EntityConfig, type TEntityType } from "data/entities";
@@ -51,6 +53,8 @@ type Options<Config = any> = {
 };
 
 const FieldMap = {
+   primary: (o: Omit<Options, "required">) =>
+      new PrimaryField(o.field_name, { ...o.config, required: true }),
    text: (o: Options) => new TextField(o.field_name, { ...o.config, required: o.is_required }),
    number: (o: Options) => new NumberField(o.field_name, { ...o.config, required: o.is_required }),
    date: (o: Options) => new DateField(o.field_name, { ...o.config, required: o.is_required }),
@@ -73,7 +77,7 @@ export class FieldPrototype {
       public type: TFieldType,
       public config: any,
       public is_required: boolean,
-   ) {}
+   ) { }
 
    required() {
       this.is_required = true;
@@ -108,6 +112,11 @@ export class FieldPrototype {
    }
 }
 
+export function primary(
+   config?: Omit<PrimaryFieldConfig, "required">,
+): PrimaryField<false> & { required: () => PrimaryField<true> } {
+   return new FieldPrototype("primary", config, false) as any;
+}
 export function text(
    config?: Omit<TextFieldConfig, "required">,
 ): TextField<false> & { required: () => TextField<true> } {
@@ -296,8 +305,8 @@ class EntityManagerPrototype<Entities extends Record<string, Entity>> extends En
 
 type Chained<R extends Record<string, (...args: any[]) => any>> = {
    [K in keyof R]: R[K] extends (...args: any[]) => any
-      ? (...args: Parameters<R[K]>) => Chained<R>
-      : never;
+   ? (...args: Parameters<R[K]>) => Chained<R>
+   : never;
 };
 type ChainedFn<
    Fn extends (...args: any[]) => Record<string, (...args: any[]) => any>,
@@ -356,22 +365,22 @@ export function em<Entities extends Record<string, Entity>>(
 
 export type InferEntityFields<T> = T extends Entity<infer _N, infer Fields>
    ? {
-        [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
-           ? Required extends true
-              ? Type
-              : Type | undefined
-           : never;
-     }
+      [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
+      ? Required extends true
+      ? Type
+      : Type | undefined
+      : never;
+   }
    : never;
 
 export type InferFields<Fields> = Fields extends Record<string, Field<any, any, any>>
    ? {
-        [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
-           ? Required extends true
-              ? Type
-              : Type | undefined
-           : never;
-     }
+      [K in keyof Fields]: Fields[K] extends { _type: infer Type; _required: infer Required }
+      ? Required extends true
+      ? Type
+      : Type | undefined
+      : never;
+   }
    : never;
 
 type Prettify<T> = {
@@ -387,10 +396,10 @@ type OptionalUndefined<
    T,
    Props extends keyof T = keyof T,
    OptionsProps extends keyof T = Props extends keyof T
-      ? undefined extends T[Props]
-         ? Props
-         : never
-      : never,
+   ? undefined extends T[Props]
+   ? Props
+   : never
+   : never,
 > = Merge<
    {
       [K in OptionsProps]?: T[K];
@@ -401,8 +410,8 @@ type OptionalUndefined<
 
 export type InferField<Field> = Field extends { _type: infer Type; _required: infer Required }
    ? Required extends true
-      ? Type
-      : Type | undefined
+   ? Type
+   : Type | undefined
    : never;
 
 export type Schemas<T extends Record<string, Entity>> = {
@@ -410,5 +419,5 @@ export type Schemas<T extends Record<string, Entity>> = {
 };
 
 export type InsertSchema<T> = Simplify<OptionalUndefined<InferEntityFields<T>>>;
-export type Schema<T> = Simplify<{ id: Generated<number> } & InsertSchema<T>>;
+export type Schema<T> = Simplify<{ id: Generated<number> | string } & InsertSchema<T>>;
 export type FieldSchema<T> = Simplify<OptionalUndefined<InferFields<T>>>;

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -173,6 +173,7 @@ export {
 
 // data prototype
 export {
+   primary,
    text,
    number,
    date,


### PR DESCRIPTION
Allows custom primary key declaration by user 

```ts
const schema = em({
  todos: entity("todos", {
    title: text(),
    done: boolean(),
  }),
  cache: entity("cache", {
    key: primary({ fillable: true }).required(),
    value: json().required(),
  }),
}, ({ index }, { cache }) => {
  index(cache).on(["key"], true)
});
```