### PR TITLE
fix(ui): stale values in `useSearch` caused by ordering

### DIFF
--- a/app/src/ui/hooks/use-search.ts
+++ b/app/src/ui/hooks/use-search.ts
@@ -17,8 +17,8 @@ export function useSearch<Schema extends s.Schema = s.Schema>(
    const defaults = useMemo(() => {
       return mergeObject(
          // @ts-ignore
-         schema.template({ withOptional: true }),
          options?.defaultValue ?? {},
+         schema.template({ withOptional: true }),
       );
    }, [JSON.stringify({ schema, dflt: options?.defaultValue })]);
    const [value, setValue] = useState<s.StaticCoerced<Schema>>(defaults);


### PR DESCRIPTION
Related to issue #393 where the first request fails in Admin UI for Database Entities

https://github.com/user-attachments/assets/f9fde504-463c-40b2-a77b-09aa2ce0e7a4