### PR TITLE
fix: add missing primary key generation for `insertMany` in `Mutator.ts` when primary key is of type `uuid`

### DIFF
--- a/app/__test__/data/specs/Mutator.spec.ts
+++ b/app/__test__/data/specs/Mutator.spec.ts
@@ -4,7 +4,7 @@ import { Entity, EntityManager } from "data/entities";
 import {
    ManyToOneRelation,
    OneToOneRelation,
-   RelationField,
+   type RelationField,
    RelationMutator,
 } from "data/relations";
 import { NumberField, TextField } from "data/fields";
@@ -41,6 +41,24 @@ describe("[data] Mutator (base)", async () => {
 
       // but expect additional fields to be present
       expect((res.data as any).not_fillable).toBeDefined();
+      expect((res.data as any).id).toBeDefined();
+   });
+
+   test("insertMany", async () => {
+      expect(em.mutator(entity).getValidatedData(payload, "create")).resolves.toEqual(payload);
+      const res = await em.mutator(entity).insertMany([
+         { label: "item 1", count: 1 },
+         { label: "item 2", count: 2 },
+         { label: "item 3", count: 3 },
+         { label: "item 4", count: 4 },
+      ]);
+
+      expect(res.data.length).toBe(4);
+      res.data.forEach((entry) => {
+         expect((entry as any).id).toBeDefined();
+         expect((entry as any).label).toStartWith("item ");
+         expect(entry.count).toBeNumber();
+      });
    });
 
    test("updateOne", async () => {

--- a/app/src/data/entities/mutation/Mutator.ts
+++ b/app/src/data/entities/mutation/Mutator.ts
@@ -312,7 +312,7 @@ export class Mutator<
 
       const validated: any[] = [];
       for (const row of data) {
-         const validatedData = {
+         let validatedData = {
             ...entity.getDefaultObject(),
             ...(await this.getValidatedData(row, "create")),
          };
@@ -326,6 +326,16 @@ export class Mutator<
             ) {
                throw new Error(`Field "${field.name}" is required`);
             }
+         }
+
+         // primary
+         const primary = entity.getPrimaryField();
+         const primary_value = primary.getNewValue();
+         if (primary_value) {
+            validatedData = {
+               [primary.name]: primary_value,
+               ...validatedData,
+            };
          }
 
          validated.push(validatedData);


### PR DESCRIPTION


https://github.com/user-attachments/assets/ce5dfcb1-e857-49da-a4d2-830d66376c3f



In `Mutator.ts`, the `insertMany` method was missing a small snippet for primary key generation, this wasn't noticed since the UI at the moment doesn't support bulk inserts and doesn't need to generate IDs because the tables were created with autoincrementing intergers, not to mention `insertOne` does generate IDs correctly 

This pr(potentially) also fixes the `SQLiteError: NOT NULL constraint failed: todos.id` error for issue #395 