### PR TITLE
add(storage): multipart upload methods in s3 adapter

### DIFF
--- a/app/__test__/api/MediaApi.spec.ts
+++ b/app/__test__/api/MediaApi.spec.ts
@@ -141,12 +141,24 @@ describe("MediaApi", () => {
 
       // upload bun file
       await matches(api.upload(file as any, { filename: "bunfile.png" }), "bunfile.png");
-
+      
       // upload via request
       await matches(api.upload(new Request(url), { filename: "request.png" }), "request.png");
-
+      
       // upload via url
       await matches(api.upload(url, { filename: "url.png" }), "url.png");
+      
+      
+      // mocked since only s3 supports chunked upload
+      await matches(
+         api.upload(file as any, { filename: "bunfile.png", chunked: true }),
+         "bunfile.png",
+      );
+      await matches(
+         api.upload(new Request(url), { filename: "request.png", chunked: true }),
+         "request.png",
+      );
+      await matches(api.upload(url, { filename: "url.png", chunked: true }), "url.png");
 
       // upload via response
       {

--- a/app/src/media/api/MediaApi.ts
+++ b/app/src/media/api/MediaApi.ts
@@ -77,6 +77,7 @@ export class MediaApi extends ModuleApi<MediaApiOptions> {
          path?: TInput;
          _init?: Omit<RequestInit, "body">;
          query?: Record<string, any>;
+         chunked?: boolean;
       },
    ): FetchPromise<ResponseObject<T>> {
       const headers = {
@@ -102,8 +103,14 @@ export class MediaApi extends ModuleApi<MediaApiOptions> {
          ...(opts?._init || {}),
          headers,
       };
+
+      const query = {
+         ...opts?.query,
+         ...(opts?.chunked !== undefined ? { chunked: opts.chunked } : {}),
+      };
+
       if (opts?.path) {
-         return this.request<T>(opts.path, opts?.query, {
+         return this.request<T>(opts.path, query, {
             ...init,
             body,
             method: "POST",
@@ -114,7 +121,7 @@ export class MediaApi extends ModuleApi<MediaApiOptions> {
          throw new Error("Invalid filename");
       }
 
-      return this.request<T>(opts?.path ?? ["upload", name], opts?.query, {
+      return this.request<T>(opts?.path ?? ["upload", name], query, {
          ...init,
          body,
          method: "POST",
@@ -129,6 +136,7 @@ export class MediaApi extends ModuleApi<MediaApiOptions> {
          path?: TInput;
          fetcher?: ApiFetcher;
          query?: Record<string, any>;
+         chunked?: boolean;
       } = {},
    ) {
       if (item instanceof Request || typeof item === "string") {
@@ -166,13 +174,17 @@ export class MediaApi extends ModuleApi<MediaApiOptions> {
          _init?: Omit<RequestInit, "body">;
          fetcher?: typeof fetch;
          overwrite?: boolean;
+         chunked?: boolean;
       },
    ): Promise<ResponseObject<FileUploadedEventData & { result: DB["media"] }>> {
-      const query = opts?.overwrite !== undefined ? { overwrite: opts.overwrite } : undefined;
+      const query = {
+         ...(opts?.overwrite !== undefined ? { overwrite: opts.overwrite } : {}),
+         ...(opts?.chunked ? { chunked: opts.chunked } : {}),
+      };
       return this.upload(item, {
          ...opts,
          path: ["entity", entity, id, field],
-         query,
+         query: Object.keys(query).length > 0 ? query : undefined,
       });
    }
 

--- a/app/src/media/api/MediaController.ts
+++ b/app/src/media/api/MediaController.ts
@@ -149,9 +149,11 @@ export class MediaController extends Controller {
             requestBody,
          }),
          jsc("param", s.object({ filename: s.string().optional() })),
+         jsc("query", s.object({ chunked: s.boolean().optional() })),
          permission(MediaPermissions.uploadFile, {}),
          async (c) => {
             const reqname = c.req.param("filename");
+            const { chunked } = c.req.valid("query");
 
             const body = await getFileFromContext(c);
             if (!body) {
@@ -165,7 +167,7 @@ export class MediaController extends Controller {
             }
 
             const filename = reqname ?? getRandomizedFilename(body as File);
-            const res = await this.getStorage().uploadFile(body, filename);
+            const res = await this.getStorage().uploadFile(body, filename, undefined, chunked);
 
             return c.json(res, HttpStatus.CREATED);
          },
@@ -188,13 +190,18 @@ export class MediaController extends Controller {
                field: s.string(),
             }),
          ),
-         jsc("query", s.object({ overwrite: s.boolean().optional() })),
+         jsc(
+            "query",
+            s.object({ overwrite: s.boolean().optional(), chunked: s.boolean().optional() }),
+         ),
+
          permission(DataPermissions.entityCreate, {
             context: (c) => ({ entity: c.req.param("entity") }),
          }),
          permission(MediaPermissions.uploadFile, {}),
          async (c) => {
             const { entity: entity_name, id: entity_id, field: field_name } = c.req.valid("param");
+            const { chunked } = c.req.valid("query");
 
             // check if entity exists
             const entity = this.media.em.entity(entity_name);
@@ -284,7 +291,7 @@ export class MediaController extends Controller {
             }
 
             const filename = getRandomizedFilename(file as File);
-            const info = await this.getStorage().uploadFile(file, filename, true);
+            const info = await this.getStorage().uploadFile(file, filename, true, chunked);
 
             const mutator = this.media.em.mutator(media_entity);
             mutator.__unstable_toggleSystemEntityCreation(false);

--- a/app/src/media/storage/Storage.ts
+++ b/app/src/media/storage/Storage.ts
@@ -4,6 +4,7 @@ import { isMimeType } from "media/storage/mime-types-tiny";
 import * as StorageEvents from "./events";
 import type { FileUploadedEventData } from "./events";
 import type { StorageAdapter } from "./StorageAdapter";
+import { StorageS3Adapter } from "media/storage/adapters/s3/StorageS3Adapter";
 
 export type FileListObject = {
    key: string;
@@ -63,8 +64,14 @@ export class Storage implements EmitsEvents {
       file: FileBody,
       name: string,
       noEmit?: boolean,
+      chunked?: boolean,
    ): Promise<FileUploadedEventData> {
-      const result = await this.#adapter.putObject(name, file);
+      const uploader =
+         chunked && this.#adapter instanceof StorageS3Adapter
+            ? this.#adapter.putObjectMultipart.bind(this.#adapter)
+            : this.#adapter.putObject.bind(this.#adapter);
+
+      const result = await uploader(name, file);
       if (typeof result === "undefined") {
          throw new Error("Failed to upload file");
       }

--- a/app/src/media/storage/adapters/s3/StorageS3Adapter.ts
+++ b/app/src/media/storage/adapters/s3/StorageS3Adapter.ts
@@ -8,7 +8,7 @@ import type {
 } from "@aws-sdk/client-s3";
 import { AwsClient } from "core/clients/aws/AwsClient";
 import { isDebug } from "core/env";
-import { isFile, pickHeaders2, parse, s, secret } from "bknd/utils";
+import { isFile, pickHeaders2, parse, s, secret, $console } from "bknd/utils";
 import { transform } from "lodash-es";
 import type { FileBody, FileListObject } from "../../Storage";
 import { StorageAdapter } from "../../StorageAdapter";
@@ -23,6 +23,8 @@ export const s3AdapterConfig = s.object(
          examples: [
             "https://{account_id}.r2.cloudflarestorage.com/{bucket}",
             "https://{bucket}.s3.{region}.amazonaws.com",
+            "https://t3.storage.dev/{bucket}",
+            "{self_hosted_s3_url}/{bucket}"
          ],
       }),
    },
@@ -34,9 +36,15 @@ export const s3AdapterConfig = s.object(
 
 export type S3AdapterConfig = s.Static<typeof s3AdapterConfig>;
 
+interface UploadPart {
+   partNumber: number;
+   etag: string;
+}
+
 export class StorageS3Adapter extends StorageAdapter {
    readonly #config: S3AdapterConfig;
    readonly client: AwsClient;
+   readonly CHUNK_SIZE = 5 * 1024 * 1024; // 5MB
 
    constructor(config: S3AdapterConfig) {
       super();
@@ -137,6 +145,215 @@ export class StorageS3Adapter extends StorageAdapter {
 
       // "df20fcb574dba1446cf5ec997940492b"
       return String(res.headers.get("etag"));
+   }
+
+   // --- Multipart Upload Methods ---
+
+   async getOrCreateUploadId(key: string): Promise<string> {
+      // Scope active upload lookup specifically to this key prefix
+      const url = this.getUrl("", { uploads: "", prefix: key });
+
+      const response = await this.client.fetch(url, { method: "GET" });
+      if (!response.ok) {
+         return await this.createUploadId(key);
+      }
+
+      const xmlText = await response.text();
+      const uploadIdMatches = [...xmlText.matchAll(/<UploadId>(.*?)<\/UploadId>/g)];
+
+      if (uploadIdMatches.length > 0) {
+         // Grab the most recent upload ID
+         const latestUploadId = uploadIdMatches[uploadIdMatches.length - 1]![1]!;
+         return latestUploadId;
+      }
+
+      return await this.createUploadId(key);
+   }
+
+   async getUploadedParts(key: string, uploadId: string): Promise<Map<number, string> | null> {
+      const partsMap = new Map<number, string>();
+      let partNumberMarker = 0;
+      let isTruncated = true;
+
+      while (isTruncated) {
+         // S3 API requires the part-number-marker to be set to the last part number received in the previous response
+         const url = this.getUrl(`${key}?uploadId=${uploadId}&part-number-marker=${partNumberMarker}`);
+         const response = await this.client.fetch(url, { method: "GET" });
+
+         if (!response.ok) {
+            console.error(
+               `ERROR: Failed to list parts for key '${key}' (status ${response.status}):`,
+               await response.text(),
+            );
+            break;
+         }
+
+         const xmlText = await response.text();
+         const partBlocks = xmlText.match(/<Part>[\s\S]*?<\/Part>/g) || [];
+
+         for (const block of partBlocks) {
+            const partNumMatch = block.match(/<PartNumber>(\d+)<\/PartNumber>/);
+            const etagMatch = block.match(/<ETag>(.*?)<\/ETag>/);
+
+            if (partNumMatch && etagMatch) {
+               const partNum = parseInt(partNumMatch[1]!, 10);
+               const etag = etagMatch[1]!.replace(/&quot;|"/g, "").trim();
+               partsMap.set(partNum, etag);
+               partNumberMarker = partNum;
+            }
+         }
+
+         isTruncated = /<IsTruncated>true<\/IsTruncated>/.test(xmlText);
+      }
+
+      return partsMap;
+   }
+
+   async createUploadId(key: string): Promise<string> {
+      const url = this.getUrl(`${key}?uploads`);
+      const response = await this.client.fetch(url, {
+         method: "POST",
+      });
+
+      if (!response.ok) {
+         throw new Error(`Failed to create upload ID: ${response.status} ${await response.text()}`);
+      }
+
+      const xmlText = await response.text();
+      const match = xmlText.match(/<UploadId>(.*?)<\/UploadId>/);
+      if (!match || !match[1])
+         throw new Error(`Could not locate UploadId in XML response: ${xmlText}`);
+      return match[1];
+   }
+
+   async uploadChunk(
+      key: string,
+      uploadId: string,
+      partNumber: number,
+      chunk: Uint8Array<ArrayBuffer>,
+   ): Promise<string> {
+      // casing of query parameters is important for S3, so we construct the URL manually
+      const url = this.getUrl(`${key}?uploadId=${uploadId}&partNumber=${partNumber}`, {});
+
+      const response = await this.client.fetch(url, {
+         method: "PUT",
+         body: chunk,
+      });
+
+      if (!response.ok) {
+         throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+
+     const etag = response.headers.get("etag") || response.headers.get("ETag");
+      if (!etag || etag === null) throw new Error(`Missing ETag header in response for part ${partNumber}`);
+
+      return etag.replace(/"/g, "").trim();
+   }
+
+   async completeMultipartUpload(
+      key: string,
+      uploadId: string,
+      parts: UploadPart[],
+   ): Promise<string> {
+      const url = this.getUrl(`${key}?uploadId=${uploadId}`);
+
+      const xmlBody = `<CompleteMultipartUpload>${parts
+         .map(
+            (part) =>
+               `<Part><PartNumber>${part.partNumber}</PartNumber><ETag>"${part.etag}"</ETag></Part>`,
+         )
+         .join("")}</CompleteMultipartUpload>`;
+
+         // $console.info({xmlBody})
+
+      const response = await this.client.fetch(url, {
+         method: "POST",
+         body: xmlBody,
+         headers: {
+            "Content-Type": "application/xml",
+         },
+      });
+
+      if (!response.ok) {
+         const errorText = await response.text();
+         $console.error({ response: errorText });
+         throw new Error(
+            `Failed to complete multipart upload: ${response.status} ${response.statusText}`,
+         );
+      }
+
+      // some provider (Tigris) put ETag in body
+      const responseText = await response.text();
+      const match = responseText.match(/<ETag>(.*?)<\/ETag>/);
+      const rawEtag = match ? match[1] : null;
+
+      let escapedEtag = rawEtag?.replace(/&#34;|&quot;/g, '"').trim();
+      if (escapedEtag && !escapedEtag.startsWith('"')) {
+         escapedEtag = `"${escapedEtag}"`;
+      }
+
+      
+      const etag = response.headers.get("etag") || response.headers.get("ETag") || escapedEtag;
+      // $console.info({
+      //    response: responseText,
+      //    headers:response.headers,
+      //    etag,
+      //    etagInBody
+      // });
+
+      // Output: '"bb56c53263bb7088a430725912ba5a81-10"' 
+      //           ^ collective hash of all chunks  ^ no. of chunks      
+      return etag as string;
+   }
+
+   async putObjectMultipart(key: string, body: FileBody) {
+      let uploadId = await this.getOrCreateUploadId(key);
+
+      let uploadedParts = await this.getUploadedParts(key, uploadId);
+
+      // Invalidate upload ID if stale or non-existent on S3
+      if (uploadedParts === null) {
+         uploadId = await this.createUploadId(key);
+         uploadedParts = (await this.getUploadedParts(key, uploadId)) || new Map();
+      }
+
+      const fileData = new Uint8Array(
+         body instanceof ArrayBuffer ? body : await (body as File).bytes(),
+      );
+      const size = fileData.byteLength;
+      if (size === 0) {
+         throw new Error("Body size is 0, cannot upload empty file");
+      }
+
+      const totalParts = Math.ceil(size / this.CHUNK_SIZE);
+      const completedParts: UploadPart[] = [];
+      const promises: Promise<void>[] = [];
+
+      for (let i = 0; i < totalParts; i++) {
+         promises.push(
+            (async () => {
+               const partNumber = i + 1;
+               const start = i * this.CHUNK_SIZE;
+               const end = Math.min(start + this.CHUNK_SIZE, size);
+               const chunk = fileData.subarray(start, end);
+
+               if (uploadedParts.has(partNumber)) {
+                  completedParts.push({
+                     partNumber,
+                     etag: uploadedParts.get(partNumber)!,
+                  });
+               } else {
+                  const etag = await this.uploadChunk(key, uploadId, partNumber, chunk);
+                  completedParts.push({ partNumber, etag });
+               }
+            })(),
+         );
+      }
+
+      await Promise.all(promises);
+
+      completedParts.sort((a, b) => a.partNumber - b.partNumber);
+      return await this.completeMultipartUpload(key, uploadId, completedParts);
    }
 
    private async headObject(

--- a/docs/content/docs/(documentation)/usage/sdk.mdx
+++ b/docs/content/docs/(documentation)/usage/sdk.mdx
@@ -375,6 +375,11 @@ const { data } = await api.media.upload("https://example.com/image.jpg");
 const { data } = await api.media.upload(item, {
   filename: "custom-name.jpg",
 });
+
+// Multipart Upload (S3 Only) 
+const { data } = await api.media.upload(item, {
+  chunked: true,
+});
 ```
 
 ### `media.uploadToEntity([entity], [id], [field], [item], [options])`


### PR DESCRIPTION
Adds multipart upload methods for S3 uploads in `StorageS3Adapter.ts` 

Adds:
- test cases (mocked)
- extend `media.upload` and `Storage` class to use this interface
- Docs to use multipart upload


<a href="https://nefer.wtr.qzz.io/booboo/multipart%20upload%20demo.mp4" target="_blank">demo video was too big for github</a>
