### PR TITLE
add(duckdb): DuckDB connection support

### DIFF
--- a/app/build.ts
+++ b/app/build.ts
@@ -83,6 +83,8 @@ const external = [
   "node:test",
   "node:assert/strict",
   "@libsql/client",
+  "@duckdb/node-api",
+  "@duckdb/node-bindings",
   "bknd",
   /^bknd\/.*/,
   "jsonv-ts",

--- a/app/package.json
+++ b/app/package.json
@@ -83,6 +83,7 @@
     "@cloudflare/vitest-pool-workers": "^0.10.4",
     "@cloudflare/workers-types": "^4.20251014.0",
     "@dagrejs/dagre": "^1.1.4",
+    "@duckdb/node-api": "^1.5.5-r.4",
     "@hono/vite-dev-server": "^0.23.0",
     "@hookform/resolvers": "^5.2.2",
     "@libsql/client": "^0.15.15",

--- a/app/src/adapter/bun/connection/DuckdbConnection.ts
+++ b/app/src/adapter/bun/connection/DuckdbConnection.ts
@@ -1,0 +1,5 @@
+export {
+   duckdb,
+   DuckdbConnection,
+   type DuckdbConfig,
+} from "data/connection/duckdb/DuckdbConnection";

--- a/app/src/adapter/bun/index.ts
+++ b/app/src/adapter/bun/index.ts
@@ -1,6 +1,7 @@
 export * from "./bun.adapter";
 export * from "../node/storage";
 export * from "./connection/BunSqliteConnection";
+export * from "./connection/DuckdbConnection";
 
 export async function writer(path: string, content: string) {
    await Bun.write(path, content);

--- a/app/src/adapter/node/connection/DuckdbConnection.ts
+++ b/app/src/adapter/node/connection/DuckdbConnection.ts
@@ -1,0 +1,5 @@
+export {
+   duckdb,
+   DuckdbConnection,
+   type DuckdbConfig,
+} from "data/connection/duckdb/DuckdbConnection";

--- a/app/src/adapter/node/index.ts
+++ b/app/src/adapter/node/index.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 export * from "./node.adapter";
 export * from "./storage";
 export * from "./connection/NodeSqliteConnection";
+export * from "./connection/DuckdbConnection";
 
 export async function writer(path: string, content: string) {
    await writeFile(path, content);

--- a/app/src/data/connection/duckdb/DuckdbAdapter.ts
+++ b/app/src/data/connection/duckdb/DuckdbAdapter.ts
@@ -1,0 +1,21 @@
+import { DialectAdapterBase } from "kysely";
+
+/**
+ * DuckDB supports transactional DDL (CREATE/ALTER TABLE can be rolled back)
+ * and `INSERT|UPDATE|DELETE ... RETURNING`.
+ */
+export class DuckdbAdapter extends DialectAdapterBase {
+   override get supportsTransactionalDdl(): boolean {
+      return true;
+   }
+
+   override get supportsReturning(): boolean {
+      return true;
+   }
+
+   override async acquireMigrationLock(): Promise<void> {
+      // single embedded instance, no cross-process migration lock needed
+   }
+
+   override async releaseMigrationLock(): Promise<void> {}
+}

--- a/app/src/data/connection/duckdb/DuckdbConnection.spec.ts
+++ b/app/src/data/connection/duckdb/DuckdbConnection.spec.ts
@@ -1,0 +1,17 @@
+import { connectionTestSuite } from "../connection-test-suite";
+import { duckdb } from "./DuckdbConnection";
+import { bunTestRunner } from "adapter/bun/test";
+import { describe } from "bun:test";
+
+describe("DuckdbConnection", () => {
+   connectionTestSuite(bunTestRunner, {
+      makeConnection: async () => {
+         const connection = await duckdb();
+         return {
+            connection,
+            dispose: () => connection.close(),
+         };
+      },
+      rawDialectDetails: [],
+   });
+});

--- a/app/src/data/connection/duckdb/DuckdbConnection.ts
+++ b/app/src/data/connection/duckdb/DuckdbConnection.ts
@@ -1,0 +1,158 @@
+import {
+   DuckDBInstance,
+   type DuckDBConnection,
+   type DuckDBInstance as TInstance,
+} from "@duckdb/node-api";
+import { Connection, type FieldSpec, type SchemaResponse } from "../Connection";
+import type { Field } from "data/fields/Field";
+import {
+   type ColumnDefinitionBuilder,
+   type ColumnDataType,
+   Kysely,
+   ParseJSONResultsPlugin,
+   type KyselyPlugin,
+} from "kysely";
+import { jsonArrayFrom, jsonBuildObject, jsonObjectFrom } from "kysely/helpers/sqlite";
+import { DuckdbDialect } from "./DuckdbDialect";
+import { isSafeBigint } from "./utils";
+
+export type DuckdbConfig = {
+   /** Database file path, or `:memory:` (default) for an in-memory database. */
+   path?: string;
+   /** DuckDB configuration options, passed to the instance (e.g. `{ threads: "1" }`). */
+   options?: Record<string, string>;
+   /** Bring your own DuckDB instance (its lifetime is then managed by you). */
+   instance?: TInstance;
+   /**
+    * Emit `REFERENCES` clauses for relation fields (default: false). DuckDB
+    * enforces foreign keys strictly but only supports `NO ACTION`, and treats
+    * row updates as delete+insert — so updating a parent row referenced by a
+    * child fails. SQLite (bknd's default) does not enforce foreign keys, so
+    * leaving them off matches the platform's effective behavior.
+    */
+   foreignKeys?: boolean;
+   excludeTables?: string[];
+   additionalPlugins?: KyselyPlugin[];
+};
+
+/**
+ * A bknd `Connection` backed by DuckDB. DuckDB has native `BOOLEAN` and `JSON`
+ * types (no SQLite-style 0/1 coercion), and integer primary keys use
+ * sequence-backed defaults instead of `AUTOINCREMENT` (DuckDB's identity
+ * columns are not implemented alongside constraints).
+ */
+export class DuckdbConnection extends Connection<DuckDBConnection> {
+   override name = "duckdb";
+
+   readonly #foreignKeys: boolean;
+   readonly #instance: Promise<DuckDBInstance>;
+   readonly #ownsInstance: boolean;
+
+   constructor(config: DuckdbConfig = {}) {
+      const plugins = [new ParseJSONResultsPlugin(), ...(config.additionalPlugins ?? [])];
+
+      // in-memory databases must NOT go through the path cache: every
+      // connection would otherwise share one catalog for the whole process.
+      // File paths are cached so multiple connections dedupe.
+      const instance = config.instance
+         ? Promise.resolve(config.instance)
+         : config.path && config.path !== ":memory:"
+           ? DuckDBInstance.fromCache(config.path, config.options)
+           : DuckDBInstance.create(config.path ?? ":memory:", config.options);
+
+      const kysely = new Kysely({
+         dialect: new DuckdbDialect({
+            instance: () => instance,
+            excludeTables: config.excludeTables,
+            plugins,
+         }),
+         plugins,
+      });
+
+      super(kysely, { jsonArrayFrom, jsonObjectFrom, jsonBuildObject }, plugins);
+
+      this.#foreignKeys = config.foreignKeys ?? false;
+      this.#instance = instance;
+      this.#ownsInstance = !config.instance;
+   }
+
+   override async init(): Promise<void> {
+      const instance = await this.#instance;
+      this.client = await instance.connect();
+      this.initialized = true;
+   }
+
+   override getFieldSchema(spec: FieldSpec): SchemaResponse {
+      this.validateFieldSpecType(spec.type);
+
+      // integers are uniformly BIGINT: primary keys and their referencing
+      // foreign keys must match exactly for DuckDB's FK checks
+      let type: ColumnDataType = spec.type;
+      switch (spec.type) {
+         case "text":
+            type = "varchar";
+            break;
+         case "real":
+            type = "double precision";
+            break;
+         case "datetime":
+         case "timestamp":
+            type = "timestamp";
+            break;
+         // integer, blob, date, boolean, json map to DuckDB type names
+         // (integer -> bigint is handled below)
+      }
+      if (spec.type === "integer") {
+         type = "bigint";
+      }
+
+      return [
+         spec.name,
+         type,
+         (col: ColumnDefinitionBuilder) => {
+            if (spec.primary) {
+               if (spec.type === "integer") {
+                  return col.primaryKey().notNull().autoIncrement();
+               }
+               return col.primaryKey().notNull();
+            }
+            if (spec.references && this.#foreignKeys) {
+               // DuckDB FKs support NO ACTION only — CASCADE/SET NULL/SET
+               // DEFAULT are parser errors, so referential actions are never
+               // emitted (and FKs are opt-in, see DuckdbConfig#foreignKeys)
+               return col.references(spec.references);
+            }
+            return col;
+         },
+      ] as const;
+   }
+
+   override toDriver(value: unknown, _field: Field): unknown {
+      if (value === undefined) {
+         return null;
+      }
+      return value;
+   }
+
+   override fromDriver(value: any, _field: Field): unknown {
+      if (typeof value === "bigint" && isSafeBigint(value)) {
+         return Number(value);
+      }
+      return value;
+   }
+
+   override async close(): Promise<void> {
+      await this.kysely.destroy();
+      this.client?.disconnectSync();
+      if (this.#ownsInstance) {
+         (await this.#instance).closeSync();
+      }
+   }
+}
+
+/** Create a bknd connection backed by DuckDB. */
+export async function duckdb(config: DuckdbConfig = {}): Promise<DuckdbConnection> {
+   const connection = new DuckdbConnection(config);
+   await connection.init();
+   return connection;
+}

--- a/app/src/data/connection/duckdb/DuckdbConnection.vi-test.ts
+++ b/app/src/data/connection/duckdb/DuckdbConnection.vi-test.ts
@@ -1,0 +1,21 @@
+import { connectionTestSuite } from "data/connection/connection-test-suite";
+import { duckdb } from "./DuckdbConnection";
+import { describe, beforeAll, afterAll } from "vitest";
+import { viTestRunner } from "adapter/node/vitest";
+import { disableConsoleLog, enableConsoleLog } from "core/utils/test";
+
+beforeAll(() => disableConsoleLog());
+afterAll(() => enableConsoleLog());
+
+describe("DuckdbConnection", () => {
+   connectionTestSuite(viTestRunner, {
+      makeConnection: async () => {
+         const connection = await duckdb();
+         return {
+            connection,
+            dispose: () => connection.close(),
+         };
+      },
+      rawDialectDetails: [],
+   });
+});

--- a/app/src/data/connection/duckdb/DuckdbDialect.ts
+++ b/app/src/data/connection/duckdb/DuckdbDialect.ts
@@ -1,0 +1,37 @@
+import type { DuckDBInstance } from "@duckdb/node-api";
+import type { Dialect, Kysely, KyselyPlugin } from "kysely";
+import { DuckdbAdapter } from "./DuckdbAdapter";
+import { DuckdbDriver } from "./DuckdbDriver";
+import { DuckdbIntrospector } from "./DuckdbIntrospector";
+import { DuckdbQueryCompiler } from "./DuckdbQueryCompiler";
+
+export type DuckdbDialectConfig = {
+   instance?: DuckDBInstance | (() => Promise<DuckDBInstance>);
+   path?: string;
+   options?: Record<string, string>;
+   excludeTables?: string[];
+   plugins?: KyselyPlugin[];
+};
+
+export class DuckdbDialect implements Dialect {
+   constructor(private readonly config: DuckdbDialectConfig = {}) {}
+
+   createAdapter(): DuckdbAdapter {
+      return new DuckdbAdapter();
+   }
+
+   createDriver(): DuckdbDriver {
+      return new DuckdbDriver(this.config);
+   }
+
+   createIntrospector(db: Kysely<any>): DuckdbIntrospector {
+      return new DuckdbIntrospector(db, {
+         excludeTables: this.config.excludeTables,
+         plugins: this.config.plugins,
+      });
+   }
+
+   createQueryCompiler(): DuckdbQueryCompiler {
+      return new DuckdbQueryCompiler();
+   }
+}

--- a/app/src/data/connection/duckdb/DuckdbDriver.ts
+++ b/app/src/data/connection/duckdb/DuckdbDriver.ts
@@ -1,0 +1,184 @@
+import type { DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
+import {
+   CompiledQuery,
+   type DatabaseConnection,
+   type Driver,
+   type QueryResult,
+   type TransactionSettings,
+} from "kysely";
+import { convertRow, toDuckdbParam } from "./utils";
+
+export type DuckdbDriverConfig = {
+   /**
+    * A DuckDB instance, or a (memoized) factory for one. When omitted, an
+    * instance is created from `path`/`options` on first use.
+    */
+   instance?: DuckDBInstance | (() => Promise<DuckDBInstance>);
+   path?: string;
+   options?: Record<string, string>;
+};
+
+const SELECTISH = /^(select|with|show|describe|pragma|explain|from)\b/i;
+
+type ExecuteFn<T> = () => Promise<T>;
+
+export class DuckdbDatabaseConnection implements DatabaseConnection {
+   constructor(
+      private readonly connection: DuckDBConnection,
+      private readonly schedule: <T>(fn: ExecuteFn<T>) => Promise<T>,
+   ) {}
+
+   async runNative(sql: string): Promise<void> {
+      await this.connection.run(sql);
+   }
+
+   async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+      return await this.schedule(async () => {
+         const parameters = compiledQuery.parameters.map(toDuckdbParam);
+         const result = await this.connection.run(
+            compiledQuery.sql,
+            parameters.length > 0 ? (parameters as never) : undefined,
+         );
+
+         const rows =
+            result.columnCount > 0
+               ? ((await result.getRowObjectsJS()) as Record<string, unknown>[]).map(convertRow)
+               : [];
+
+         const numAffectedRows =
+            !SELECTISH.test(compiledQuery.sql) && result.rowsChanged > 0
+               ? BigInt(result.rowsChanged)
+               : undefined;
+         return {
+            rows: rows as R[],
+            ...(numAffectedRows !== undefined ? { numAffectedRows } : {}),
+         };
+      });
+   }
+
+   async *streamQuery<R>(compiledQuery: CompiledQuery): AsyncIterableIterator<QueryResult<R>> {
+      yield await this.executeQuery(compiledQuery);
+   }
+}
+
+/**
+ * DuckDB is an embedded single-writer engine, so like the sqlite connections
+ * this driver serves all queries through ONE native connection with
+ * serialized execution:
+ *
+ * - non-transaction queries run in submission order (schema sync fires
+ *   parallel `create table` / `create index` batches that depend on order)
+ * - while a transaction is open it owns the connection exclusively; other
+ *   queries wait until commit/rollback
+ */
+export class DuckdbDriver implements Driver {
+   private instance?: Promise<DuckDBInstance>;
+   private native?: DuckDBConnection;
+   private dbConn?: DuckdbDatabaseConnection;
+
+   private queueTail: Promise<unknown> = Promise.resolve();
+   private trxConn?: DuckdbDatabaseConnection;
+   private trxDone: Promise<void> = Promise.resolve();
+   private trxRelease?: () => void;
+
+   constructor(private readonly config: DuckdbDriverConfig = {}) {}
+
+   private async getInstance(): Promise<DuckDBInstance> {
+      this.instance ??=
+         typeof this.config.instance === "function"
+            ? this.config.instance()
+            : this.config.instance
+              ? Promise.resolve(this.config.instance)
+              : import("@duckdb/node-api").then(({ DuckDBInstance }) =>
+                   DuckDBInstance.fromCache(this.config.path ?? ":memory:", this.config.options),
+                );
+      return await this.instance;
+   }
+
+   private enqueue<T>(fn: ExecuteFn<T>): Promise<T> {
+      const run = this.queueTail.then(fn, fn);
+      this.queueTail = run.then(
+         () => {},
+         () => {},
+      );
+      return run;
+   }
+
+   private async schedule<T>(conn: DuckdbDatabaseConnection, fn: ExecuteFn<T>): Promise<T> {
+      if (this.trxConn === conn) {
+         return fn();
+      }
+      while (this.trxConn) {
+         await this.trxDone;
+      }
+      return this.enqueue(fn);
+   }
+
+   async init(): Promise<void> {}
+
+   async acquireConnection(): Promise<DuckdbDatabaseConnection> {
+      if (!this.dbConn) {
+         const instance = await this.getInstance();
+         this.native = await instance.connect();
+         this.dbConn = new DuckdbDatabaseConnection(this.native, (fn) =>
+            this.schedule(this.dbConn!, fn),
+         );
+      }
+      return this.dbConn;
+   }
+
+   async releaseConnection(_connection: DuckdbDatabaseConnection): Promise<void> {}
+
+   async beginTransaction(
+      connection: DuckdbDatabaseConnection,
+      _settings: TransactionSettings,
+   ): Promise<void> {
+      if (this.trxConn) {
+         throw new Error("a transaction is already in progress on this connection");
+      }
+      await this.queueTail;
+      this.trxConn = connection;
+      this.trxDone = new Promise((resolve) => {
+         this.trxRelease = resolve;
+      });
+      await connection.runNative("BEGIN TRANSACTION");
+   }
+
+   async commitTransaction(connection: DuckdbDatabaseConnection): Promise<void> {
+      await connection.runNative("COMMIT");
+      this.endTransaction();
+   }
+
+   async rollbackTransaction(connection: DuckdbDatabaseConnection): Promise<void> {
+      await connection.runNative("ROLLBACK");
+      this.endTransaction();
+   }
+
+   private endTransaction(): void {
+      this.trxConn = undefined;
+      this.trxRelease?.();
+      this.trxRelease = undefined;
+   }
+
+   async savepoint(connection: DuckdbDatabaseConnection, savepointName: string): Promise<void> {
+      await connection.runNative(`SAVEPOINT ${savepointName}`);
+   }
+
+   async rollbackToSavepoint(
+      connection: DuckdbDatabaseConnection,
+      savepointName: string,
+   ): Promise<void> {
+      await connection.runNative(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+   }
+
+   async releaseSavepoint(
+      connection: DuckdbDatabaseConnection,
+      savepointName: string,
+   ): Promise<void> {
+      await connection.runNative(`RELEASE SAVEPOINT ${savepointName}`);
+   }
+
+   async destroy(): Promise<void> {
+      // instance lifetime is owned by the connection factory, not the driver
+   }
+}

--- a/app/src/data/connection/duckdb/DuckdbIntrospector.ts
+++ b/app/src/data/connection/duckdb/DuckdbIntrospector.ts
@@ -1,0 +1,107 @@
+import { BaseIntrospector } from "../BaseIntrospector";
+import type { IndexMetadata } from "../Connection";
+import { sql, type Kysely, type KyselyPlugin, type TableMetadata } from "kysely";
+import { parseIndexColumns } from "./utils";
+
+export type TableSpec = TableMetadata & {
+   indices: IndexMetadata[];
+};
+
+type InformationSchemaTable = {
+   table_name: string;
+   table_type: string;
+};
+
+type InformationSchemaColumn = {
+   column_name: string;
+   data_type: string;
+   is_nullable: string;
+   column_default: string | null;
+   is_identity: string | null;
+};
+
+type DuckdbIndex = {
+   index_name: string;
+   table_name: string;
+   is_unique: boolean;
+   expressions: string;
+};
+
+function isNextvalDefault(columnDefault: string | null): boolean {
+   return columnDefault !== null && columnDefault.toLowerCase().startsWith("nextval(");
+}
+
+export class DuckdbIntrospector extends BaseIntrospector {
+   constructor(
+      db: Kysely<any>,
+      config: { excludeTables?: string[]; plugins?: KyselyPlugin[] } = {},
+   ) {
+      super(db, config);
+   }
+
+   override async getSchemas(): Promise<{ name: string }[]> {
+      return [{ name: "main" }];
+   }
+
+   override async getSchemaSpec(): Promise<TableSpec[]> {
+      const excluded = new Set(this.getExcludedTableNames());
+
+      const tables = await this.executeWithPlugins<InformationSchemaTable[]>(sql`
+         select table_name, table_type
+         from information_schema.tables
+         where table_schema = 'main' and table_type = 'BASE TABLE'
+      `);
+
+      const indices = await this.getIndicesInternal();
+
+      const specs: TableSpec[] = [];
+      for (const table of tables) {
+         if (excluded.has(table.table_name)) {
+            continue;
+         }
+
+         const columns = await this.executeWithPlugins<InformationSchemaColumn[]>(sql`
+            select column_name, data_type, is_nullable, column_default, is_identity
+            from information_schema.columns
+            where table_schema = 'main' and table_name = ${table.table_name}
+            order by ordinal_position
+         `);
+
+         specs.push({
+            name: table.table_name,
+            isView: false,
+            columns: columns.map((column) => ({
+               name: column.column_name,
+               dataType: column.data_type,
+               isNullable: column.is_nullable === "YES",
+               // DuckDB's is_identity is unimplemented; auto-incrementing columns
+               // are the ones whose default pulls from a sequence
+               isAutoIncrementing:
+                  column.is_identity === "YES" || isNextvalDefault(column.column_default),
+               hasDefaultValue: column.column_default !== null,
+            })),
+            indices: indices
+               .filter((index) => index.table_name === table.table_name)
+               .map((index) => ({
+                  name: index.index_name,
+                  table: index.table_name,
+                  isUnique: index.is_unique,
+                  columns: parseIndexColumns(index.expressions).map((name, order) => ({
+                     name,
+                     order,
+                  })),
+               })),
+         });
+      }
+      return specs;
+   }
+
+   private async getIndicesInternal(): Promise<DuckdbIndex[]> {
+      // constraint-backed indexes (PRIMARY KEY / UNIQUE constraints) surface in
+      // duckdb_constraints(); duckdb_indexes() only lists explicit CREATE INDEX
+      return await this.executeWithPlugins<DuckdbIndex[]>(sql`
+         select index_name, table_name, is_unique, expressions
+         from duckdb_indexes()
+      `);
+   }
+}

--- a/app/src/data/connection/duckdb/DuckdbQueryCompiler.ts
+++ b/app/src/data/connection/duckdb/DuckdbQueryCompiler.ts
@@ -1,0 +1,175 @@
+import {
+   type AlterTableNode,
+   type ColumnDefinitionNode,
+   type CreateTableNode,
+   type LimitNode,
+   type OffsetNode,
+   type OperationNode,
+   SqliteQueryCompiler,
+} from "kysely";
+
+/**
+ * DuckDB shares SQLite's surface for the parts kysely emits (`?` placeholders,
+ * `"` quoted identifiers), but has no `AUTOINCREMENT` and its `GENERATED AS
+ * IDENTITY` columns are not implemented alongside constraints (DuckDB 1.4/1.5
+ * throw "Constraint not implemented!"). The supported auto-increment pattern
+ * is a sequence-backed column default:
+ *
+ *    create sequence if not exists "seq_test_id";
+ *    create table "test" (
+ *      "id" bigint default nextval('seq_test_id') not null primary key, ...
+ *    );
+ *
+ * The sequence DDL is prepended to the same compiled statement — DuckDB
+ * executes multi-statement strings in one call, and DDL carries no bound
+ * parameters.
+ */
+export class DuckdbQueryCompiler extends SqliteQueryCompiler {
+   #table?: string;
+
+   override visitCreateTable(node: CreateTableNode): void {
+      this.#table = tableName(node.table);
+      try {
+         for (const column of node.columns) {
+            if (column.autoIncrement) {
+               this.append(
+                  `create sequence if not exists "${sequenceName(this.#table, column)}"; `,
+               );
+            }
+         }
+         super.visitCreateTable(node);
+      } finally {
+         this.#table = undefined;
+      }
+   }
+
+   override visitAlterTable(node: AlterTableNode): void {
+      this.#table = tableName(node.table);
+      try {
+         for (const alteration of node.columnAlterations ?? []) {
+            if (alteration.kind === "AddColumnNode" && alteration.column.autoIncrement) {
+               this.append(
+                  `create sequence if not exists "${sequenceName(this.#table, alteration.column)}"; `,
+               );
+            }
+         }
+         super.visitAlterTable(node);
+      } finally {
+         this.#table = undefined;
+      }
+   }
+
+   /**
+    * DuckDB requires constant limits inside correlated subqueries ("non-
+    * constant limit not supported"), and kysely always parameterizes
+    * limit/offset. Inline numeric values as literals instead — fine for an
+    * embedded database with no plan cache.
+    */
+   override visitLimit(node: LimitNode): void {
+      this.append("limit ");
+      if (!this.appendImmediate(node.limit)) {
+         this.visitNode(node.limit);
+      }
+   }
+
+   override visitOffset(node: OffsetNode): void {
+      this.append("offset ");
+      if (!this.appendImmediate(node.offset)) {
+         this.visitNode(node.offset);
+      }
+   }
+
+   private appendImmediate(node: OperationNode): boolean {
+      if (node?.kind === "ValueNode") {
+         const value = (node as { value?: unknown }).value;
+         if (typeof value === "number" || typeof value === "bigint") {
+            this.append(String(value));
+            return true;
+         }
+      }
+      return false;
+   }
+
+   override visitColumnDefinition(node: ColumnDefinitionNode): void {
+      this.visitNode(node.column);
+      this.append(" ");
+      this.visitNode(node.dataType);
+      if (node.unsigned) {
+         this.append(" unsigned");
+      }
+      if (node.frontModifiers && node.frontModifiers.length > 0) {
+         this.append(" ");
+         this.compileList(node.frontModifiers, " ");
+      }
+      if (node.generated) {
+         this.append(" ");
+         this.visitNode(node.generated);
+      }
+      if (node.identity) {
+         this.append(" identity");
+      }
+      if (node.defaultTo) {
+         this.append(" ");
+         this.visitNode(node.defaultTo);
+      }
+      if (node.autoIncrement) {
+         this.append(` default nextval('${sequenceName(this.#table, node)}')`);
+      }
+      if (node.notNull) {
+         this.append(" not null");
+      }
+      if (node.unique) {
+         this.append(" unique");
+      }
+      if (node.nullsNotDistinct) {
+         this.append(" nulls not distinct");
+      }
+      if (node.primaryKey) {
+         this.append(" primary key");
+      }
+      if (node.references) {
+         this.append(" ");
+         this.visitNode(node.references);
+      }
+      if (node.check) {
+         this.append(" ");
+         this.visitNode(node.check);
+      }
+      if (node.endModifiers && node.endModifiers.length > 0) {
+         this.append(" ");
+         this.compileList(node.endModifiers, " ");
+      }
+   }
+}
+
+function tableName(node: unknown): string {
+   if (!node || typeof node !== "object") {
+      return "";
+   }
+   const anyNode = node as Record<string, any>;
+   if (anyNode.kind === "TableNode") {
+      return identifierName(anyNode.table?.identifier);
+   }
+   return identifierName(anyNode.identifier ?? node);
+}
+
+function identifierName(node: unknown): string {
+   if (!node || typeof node !== "object") {
+      return "";
+   }
+   const anyNode = node as Record<string, any>;
+   return anyNode.name ?? "";
+}
+
+function columnName(node: ColumnDefinitionNode): string {
+   const anyColumn = node.column as Record<string, any>;
+   return identifierName(anyColumn?.column ?? anyColumn);
+}
+
+function sequenceName(table: string | undefined, node: ColumnDefinitionNode): string {
+   const sanitized = `${table}_${columnName(node)}`
+      .toLowerCase()
+      .replace(/[^a-z0-9_]/g, "_")
+      .replace(/^_+/, "");
+   return `seq_${sanitized}`;
+}

--- a/app/src/data/connection/duckdb/utils.ts
+++ b/app/src/data/connection/duckdb/utils.ts
@@ -1,0 +1,74 @@
+import { blobValue, timestampValue } from "@duckdb/node-api";
+
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+
+export function isSafeBigint(value: bigint): boolean {
+   return value >= MIN_SAFE && value <= MAX_SAFE;
+}
+
+/**
+ * kysely parameters may contain JS values that @duckdb/node-api cannot infer
+ * a DuckDB type for (plain `Date`, `Uint8Array`) or that we want normalized
+ * (bigint within safe integer range).
+ */
+export function toDuckdbParam(value: unknown): unknown {
+   if (value === undefined) {
+      return null;
+   }
+   if (value instanceof Date) {
+      return timestampValue(BigInt(Math.round(value.getTime() * 1000)));
+   }
+   if (value instanceof Uint8Array) {
+      return blobValue(value);
+   }
+   if (typeof value === "bigint" && isSafeBigint(value)) {
+      return Number(value);
+   }
+   return value;
+}
+
+/** DuckDB returns bigint for BIGINT/HUGEINT columns; bknd expects JS numbers. */
+export function fromDuckdbValue(value: unknown): unknown {
+   if (typeof value === "bigint" && isSafeBigint(value)) {
+      return Number(value);
+   }
+   return value;
+}
+
+export function convertRow(row: Record<string, unknown>): Record<string, unknown> {
+   const out: Record<string, unknown> = {};
+   for (const key in row) {
+      out[key] = fromDuckdbValue(row[key]);
+   }
+   return out;
+}
+
+/**
+ * Parse a `duckdb_indexes().expressions` value into column names. Plain column
+ * indexes report like `[a, b]` (or `['"a"']` when the DDL used quoted
+ * identifiers); expression indexes report quoted SQL like `['(lower(b))']` and
+ * are excluded.
+ */
+export function parseIndexColumns(expressions: unknown): string[] {
+   if (typeof expressions !== "string") {
+      return [];
+   }
+   let list = expressions.trim();
+   if (list.startsWith("[") && list.endsWith("]")) {
+      list = list.slice(1, -1);
+   }
+   return list
+      .split(",")
+      .map((part) => {
+         let entry = part.trim();
+         if (/^'.*'$/.test(entry)) {
+            entry = entry.slice(1, -1).trim();
+         }
+         if (/^".*"$/.test(entry)) {
+            entry = entry.slice(1, -1);
+         }
+         return entry;
+      })
+      .filter((name) => /^[A-Za-z_][\w ]*$/.test(name));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@cloudflare/vitest-pool-workers": "^0.10.4",
         "@cloudflare/workers-types": "^4.20251014.0",
         "@dagrejs/dagre": "^1.1.4",
+        "@duckdb/node-api": "^1.5.5-r.4",
         "@hono/vite-dev-server": "^0.23.0",
         "@hookform/resolvers": "^5.2.2",
         "@libsql/client": "^0.15.15",
@@ -543,6 +544,26 @@
     "@dagrejs/dagre": ["@dagrejs/dagre@1.1.8", "", { "dependencies": { "@dagrejs/graphlib": "2.2.4" } }, "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw=="],
 
     "@dagrejs/graphlib": ["@dagrejs/graphlib@2.2.4", "", {}, "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw=="],
+
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.5-r.4", "", { "dependencies": { "@duckdb/node-bindings": "1.5.5-r.4" } }, "sha512-8v0CZNo7aM6GQCNUHERGTrZWIfss8xKzZPF3ACNhPdMMrt7UjkNI5nRQ9FTFO7Yx8ghxYxVpdotmBBMQ5vXUOA=="],
+
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.5-r.4", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.5-r.4", "@duckdb/node-bindings-darwin-x64": "1.5.5-r.4", "@duckdb/node-bindings-linux-arm64": "1.5.5-r.4", "@duckdb/node-bindings-linux-arm64-musl": "1.5.5-r.4", "@duckdb/node-bindings-linux-x64": "1.5.5-r.4", "@duckdb/node-bindings-linux-x64-musl": "1.5.5-r.4", "@duckdb/node-bindings-win32-arm64": "1.5.5-r.4", "@duckdb/node-bindings-win32-x64": "1.5.5-r.4" } }, "sha512-n+4hEfjp4vny3BuWn5p1Gh5CzHaPRxoI8TzTytxL1GMlIKKrXcg/o6sSAjrsROUXGAM4WQCiWPLKnPsjJJSggg=="],
+
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.5-r.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4OdO3pkoJzAZDnZ2iyehi67XL4+WqHPCGYWbyAsYyhGJS+WscGrAnFhMhHudMM2XF8pIEM2tuOKMmwWnTNN2wQ=="],
+
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.5-r.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-WHg3E+TupdujG31LGujMMcmtPIdW6rqRHeihlKgJR8EMetHycoYkwYxRud0niitJvS+uV0du/6pdemzs3HG9GQ=="],
+
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.5-r.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-VIeHMpYAKpGiWZ4QYsOhODAHDEcXcn089aKty0MFsMEKaEfRJWixKwnwXy/ba2/wwFmnPiSFhKNqygj2BrQbqw=="],
+
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.5-r.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Tswnf+/XWpOcFJNUUu1fkFIX/su4tMcnNz0ZV0Nru3/CkJKIMwBh+VL4SM9YV4zPK90GC4Lm8gzafjc1qDmfyQ=="],
+
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.5-r.4", "", { "os": "linux", "cpu": "x64" }, "sha512-EY+CL/4h8MQZd9MxTBq+98m3U9osmvHBwhE9b5fMWQGt2I6p1j8fvX0SXiwy9KBfQIbjVUOf5XvGdXncI54KSg=="],
+
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.5-r.4", "", { "os": "linux", "cpu": "x64" }, "sha512-h0ixrgGHtHh+C/Fu1eAL9hX4iCf8yuyJN6Y24Gh8axXXP8UuSh0rQRAQUQTYarQ8pm2qSG/67ZYjyYYydD+J/w=="],
+
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.5-r.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-uorAnySIMwWkRDuUhM1yTDxWIislnX8mndhFIw6r4VKhVW61HEOOMX5oAgkSQFII4RNWpC5PCcUAEhSATgNvVQ=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.5-r.4", "", { "os": "win32", "cpu": "x64" }, "sha512-X9XGcWQ10P3mvUIaMXXk2bi94Cow7b/ziTPMKxJ0U8U3wQPxsLzEUP7D7C/KrBWINl5am2k+5SkDVyA/THUgPg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.3.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw=="],
 
@@ -3846,7 +3867,7 @@
 
     "@babel/traverse/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "@bknd/plasmic/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@bknd/plasmic/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@bundled-es-modules/tough-cookie/tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
@@ -3855,6 +3876,8 @@
     "@cloudflare/vitest-pool-workers/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "@cypress/request/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
+    "@duckdb/node-bindings/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -4750,7 +4773,7 @@
 
     "@babel/preset-env/babel-plugin-polyfill-regenerator/@babel/helper-define-polyfill-provider": ["@babel/helper-define-polyfill-provider@0.6.3", "", { "dependencies": { "@babel/helper-compilation-targets": "^7.22.6", "@babel/helper-plugin-utils": "^7.22.5", "debug": "^4.1.1", "lodash.debounce": "^4.0.8", "resolve": "^1.14.2" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg=="],
 
-    "@bknd/plasmic/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "@bknd/plasmic/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "@bundled-es-modules/tough-cookie/tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 

--- a/docs/content/docs/(documentation)/usage/database.mdx
+++ b/docs/content/docs/(documentation)/usage/database.mdx
@@ -12,6 +12,7 @@ Currently supported and tested databases are:
 - SQLite (embedded): Node.js SQLite, Bun SQLite, LibSQL, SQLocal
 - SQLite (remote): Turso, Cloudflare D1
 - Postgres: Vanilla Postgres, Supabase, Neon, Xata
+- DuckDB (embedded): via `@duckdb/node-api`
 
 By default, bknd will try to use a SQLite database in-memory. Depending on your runtime, a different SQLite implementation will be used.
 
@@ -286,6 +287,39 @@ serve({
   connection: xataConnection({ xata }),
 });
 ```
+
+## DuckDB
+
+[DuckDB](https://duckdb.org) is an embedded analytics-grade database. The `duckdb` connection ships with a dedicated Kysely dialect and runs on the Node.js and Bun runtimes via the native `@duckdb/node-api` bindings.
+
+```ts
+import { serve } from "bknd/adapter/node";
+import { duckdb } from "bknd/adapter/node";
+
+serve({
+  connection: await duckdb({ path: "data.db" }),
+});
+```
+
+Omitting `path` uses an in-memory database. You can also pass [DuckDB configuration options](https://duckdb.org/docs/configuration/overview) or bring your own instance:
+
+```ts
+import { duckdb } from "bknd/adapter/node";
+import { DuckDBInstance } from "@duckdb/node-api";
+
+const connection = await duckdb({
+  path: "data.db",
+  options: { threads: "1" },
+  // instance: await DuckDBInstance.create("data.db"),
+  // foreignKeys: true,
+});
+```
+
+DuckDB specifics to be aware of:
+
+- Integer primary keys use sequence-backed defaults (`create sequence` + `default nextval(...)`) because DuckDB's `GENERATED AS IDENTITY` is not implemented alongside constraints. This is handled transparently, including introspection.
+- Foreign keys are **opt-in** (`foreignKeys: true`). DuckDB only supports `NO ACTION` referential behavior and treats row updates as delete+insert, so updating a parent row referenced by a child errors. SQLite — bknd's default — does not enforce foreign keys, which is why they are off by default here as well.
+- DuckDB is an embedded single-writer engine: one process per database file, queries are serialized on a single connection. It shines for local apps and read-heavy/analytics-style workloads, not for multi-process OLTP.
 
 ## Custom Connection
 


### PR DESCRIPTION
# DuckDB connection support

Implements #400.

## Summary

Adds DuckDB as a first-class connection backend: a `duckdb/` connection family in `data/connection/` (dedicated Kysely dialect — driver, adapter, query compiler, introspector) with the `duckdb()` factory exported from the **node** and **bun** adapters via `@duckdb/node-api` (native bindings, so it stays out of the root barrel and browser/edge bundles — same placement rationale as `nodeSqlite`).

```ts
import { serve, duckdb } from "bknd/adapter/node";

serve({
  connection: await duckdb({ path: "data.db" }), // omit for :memory:
});
```

## Design notes (all engine findings verified empirically on DuckDB 1.4.5 LTS and 1.5.5)

- **Auto-increment**: DuckDB's `GENERATED AS IDENTITY` is not implemented alongside constraints (`Constraint not implemented!`), so integer PKs use `create sequence` + `default nextval('seq_<table>_<col>')`. The query compiler prepends the sequence DDL to the compiled `create table` / `alter table add column` statement — DuckDB executes multi-statement strings in one call and DDL carries no bound parameters. Introspection reports `column_default like 'nextval(%'` as auto-incrementing (`is_identity` exists but is always null).
- **Execution model**: one shared native connection with FIFO serialization; an open transaction holds it exclusively. Schema sync's parallel `create table` / `create index` batches depend on statement ordering (a per-acquire connection model races and fails).
- **Correlated subqueries** require constant limits, while kysely parameterizes `limit`/`offset` — the compiler inlines numeric limits as literals.
- **Types**: `integer → BIGINT` uniformly (DuckDB FK checks require exact type matches between PK and referencing columns), `text → VARCHAR`, `real → DOUBLE PRECISION`, `json → JSON`, `boolean → BOOLEAN` (native), `datetime/timestamp → TIMESTAMP`.
- **Foreign keys are opt-in** (`foreignKeys: true`): DuckDB only supports `NO ACTION` behavior and treats row updates as delete+insert, so updating a referenced parent row errors. SQLite (bknd's default) does not enforce FKs — off-by-default matches that effective behavior.
- `:memory:` instances bypass `DuckDBInstance.fromCache` so each connection gets an isolated catalog; file paths use the cache so multiple connections dedupe.

## Changes

- `app/src/data/connection/duckdb/` — connection + dialect (+ `utils`)
- `app/src/adapter/{node,bun}/connection/DuckdbConnection.ts` — factory re-exports
- `app/build.ts` — `@duckdb/node-api` + `@duckdb/node-bindings` added to build externals (native bindings can't be bundled; mirrors the `@libsql/client` precedent)
- `app/package.json` — `@duckdb/node-api` devDependency
- specs: `DuckdbConnection.spec.ts` (bun) + `DuckdbConnection.vi-test.ts` (vitest), both running the shared `connectionTestSuite`
- docs: DuckDB section in `usage/database`

## Testing

- `connectionTestSuite` passes on **both** runners: bun 9/9, vitest 9/9 (63/63 across the whole node suite including it)
- Full `bun run build:ci`: all 20 targets build
- `bun run types`: no new errors (one pre-existing error in `src/ui/client/utils/AppReduced.ts` also present on `main`)
- Manually verified end-to-end: live HTTP server on a DuckDB file — CRUD with sequence-generated ids, unique-constraint rejection, `with` relation queries, uuid primary format, and persistence confirmed by reopening the `.db` with raw `@duckdb/node-api`

## AI-Generated Code

This PR was pair-programed with AI (ZCode / GLM / Claude). The work proceeded from research through implementation, with key human decisions on approach.


All code has been reviewed line-by-line by the contributor.
